### PR TITLE
fix wrong binary_sensor type in some cases.

### DIFF
--- a/app/sensors.py
+++ b/app/sensors.py
@@ -45,7 +45,7 @@ class sensor:
         self.binary = False
         # self.device_class = None
         self.config_topic = sensor_config_topic.format(id=self.id)
-        if self.elem_value == False or self.elem_value:
+        if 'unit_of_measurement' not in tydom_attributes_payload.keys() and (self.elem_value == False or self.elem_value):
             self.binary = True
             self.json_attributes_topic = binary_sensor_json_attributes_topic.format(
                 id=self.id)


### PR DESCRIPTION
example :
Binary sensor created / updated :  energyInstantTi1P_tydom__Équipement_conso_1 0