### PR TITLE
Better support for missing headers/parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 **/__pycache__/
 **/node_modules/
+.DS_Store

--- a/app/alarm_control_panel.py
+++ b/app/alarm_control_panel.py
@@ -103,7 +103,7 @@ class Alarm:
     # def __init__(self, name, elem_name, tydom_attributes_payload,
     # attributes_topic_from_device, mqtt=None):
 
-    async def put_alarm_state(tydom_client, device_id, alarm_id, home_zone, night_zone, asked_state=None):
+    async def put_alarm_state(self, tydom_client, device_id, alarm_id, home_zone, night_zone, asked_state=None):
         # logger.debug("%s %s %s %s", tydom_client, device_id, alarm_id, asked_state)
 
         value = None

--- a/app/alarm_control_panel.py
+++ b/app/alarm_control_panel.py
@@ -103,7 +103,8 @@ class Alarm:
     # def __init__(self, name, elem_name, tydom_attributes_payload,
     # attributes_topic_from_device, mqtt=None):
 
-    async def put_alarm_state(self, tydom_client, device_id, alarm_id, home_zone, night_zone, asked_state=None):
+    @staticmethod
+    async def put_alarm_state(tydom_client, device_id, alarm_id, home_zone, night_zone, asked_state=None):
         # logger.debug("%s %s %s %s", tydom_client, device_id, alarm_id, asked_state)
 
         value = None

--- a/app/boiler.py
+++ b/app/boiler.py
@@ -153,20 +153,23 @@ class Boiler:
 
         # logger.info("Boiler created / updated : %s %s %s", self.name, self.id, self.current_position)
 
+    @staticmethod
     async def put_temperature(tydom_client, device_id, boiler_id, set_setpoint):
         logger.info("%s %s %s", boiler_id, 'set_setpoint', set_setpoint)
         if not (set_setpoint == ''):
             await tydom_client.put_devices_data(device_id, boiler_id, 'setpoint', set_setpoint)
 
-    async def put_hvacMode(tydom_client, device_id, boiler_id, set_hvacMode):
-        logger.info("%s %s %s", boiler_id, 'set_hvacMode', set_hvacMode)
-        if set_hvacMode == 'off':
+    @staticmethod
+    async def put_hvac_mode(tydom_client, device_id, boiler_id, set_hvac_mode):
+        logger.info("%s %s %s", boiler_id, 'set_hvacMode', set_hvac_mode)
+        if set_hvac_mode == 'off':
             await tydom_client.put_devices_data(device_id, boiler_id, 'thermicLevel', 'STOP')
         else:
             await tydom_client.put_devices_data(device_id, boiler_id, 'thermicLevel', 'COMFORT')
             await tydom_client.put_devices_data(device_id, boiler_id, 'setpoint', '10')
 
-    async def put_thermicLevel(tydom_client, device_id, boiler_id, set_thermicLevel):
-        logger.info("%s %s %s", boiler_id, 'thermicLevel', set_thermicLevel)
-        if not (set_thermicLevel == ''):
-            await tydom_client.put_devices_data(device_id, boiler_id, 'thermicLevel', set_thermicLevel)
+    @staticmethod
+    async def put_thermic_level(tydom_client, device_id, boiler_id, set_thermic_level):
+        logger.info("%s %s %s", boiler_id, 'thermicLevel', set_thermic_level)
+        if not (set_thermic_level == ''):
+            await tydom_client.put_devices_data(device_id, boiler_id, 'thermicLevel', set_thermic_level)

--- a/app/light.py
+++ b/app/light.py
@@ -124,12 +124,14 @@ class Light:
     # def __init__(self, name, elem_name, tydom_attributes_payload,
     # attributes_topic_from_device, mqtt=None):
 
+    @staticmethod
     async def put_level(tydom_client, device_id, light_id, level):
         logger.info("%s %s %s", light_id, 'level', level)
         if not (level == ''):
             await tydom_client.put_devices_data(device_id, light_id, 'level', level)
 
-    async def put_levelCmd(tydom_client, device_id, light_id, levelCmd):
-        logger.info("%s %s %s", light_id, 'levelCmd', levelCmd)
-        if not (levelCmd == ''):
-            await tydom_client.put_devices_data(device_id, light_id, 'levelCmd', levelCmd)
+    @staticmethod
+    async def put_level_cmd(tydom_client, device_id, light_id, level_cmd):
+        logger.info("%s %s %s", light_id, 'levelCmd', level_cmd)
+        if not (level_cmd == ''):
+            await tydom_client.put_devices_data(device_id, light_id, 'levelCmd', level_cmd)

--- a/app/main.py
+++ b/app/main.py
@@ -41,10 +41,11 @@ TYDOM_ALARM_PIN = None
 TYDOM_ALARM_HOME_ZONE = 1
 TYDOM_ALARM_NIGHT_ZONE = 2
 
+data_options_path = '/data/options.json'
 
 try:
-    with open('/data/options.json') as f:
-        logger.info('/data/options.json detected ! Hassio Addons Environnement : parsing options.json....')
+    with open(data_options_path) as f:
+        logger.info(data_options_path + ' detected ! Hassio Addons Environnement : parsing options.json....')
         try:
             data = json.load(f)
             logger.debug(data)

--- a/app/main.py
+++ b/app/main.py
@@ -42,8 +42,7 @@ TYDOM_ALARM_PIN = None
 TYDOM_ALARM_HOME_ZONE = 1
 TYDOM_ALARM_NIGHT_ZONE = 2
 
-# data_options_path = '/data/options.json'
-data_options_path = "options.json"
+data_options_path = "/data/options.json"
 
 try:
     with open(data_options_path) as f:

--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,8 @@ import socket
 import websockets
 from logger import logger
 import logging
-#import uvloop
+
+# import uvloop
 
 from mqtt_client import MQTT_Hassio
 from tydomConnector import TydomWebSocketClient
@@ -18,21 +19,21 @@ from tydomMessagehandler import TydomMessageHandler
 logger = logging.getLogger(__name__)
 
 # HASSIO ADDON
-logger.info('~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
-logger.info('~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
-logger.info('~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+logger.info("~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+logger.info("~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+logger.info("~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
 
-logger.info('STARTING TYDOM2MQTT')
+logger.info("STARTING TYDOM2MQTT")
 
-logger.info('Detecting environnement......')
+logger.info("Detecting environnement......")
 
 # uvloop.install()
-#logger.info('uvloop init OK')
+# logger.info('uvloop init OK')
 # DEFAULT VALUES
 
 
-TYDOM_IP = 'mediation.tydom.com'
-MQTT_HOST = 'localhost'
+TYDOM_IP = "mediation.tydom.com"
+MQTT_HOST = "localhost"
 MQTT_PORT = 1883
 MQTT_USER = ""
 MQTT_PASSWORD = ""
@@ -41,73 +42,86 @@ TYDOM_ALARM_PIN = None
 TYDOM_ALARM_HOME_ZONE = 1
 TYDOM_ALARM_NIGHT_ZONE = 2
 
-data_options_path = '/data/options.json'
+# data_options_path = '/data/options.json'
+data_options_path = "options.json"
 
 try:
     with open(data_options_path) as f:
-        logger.info(data_options_path + ' detected ! Hassio Addons Environnement : parsing options.json....')
+        logger.info(
+            f"{data_options_path} detected ! Hassio Addons Environnement : parsing options.json...."
+        )
         try:
             data = json.load(f)
             logger.debug(data)
 
             # CREDENTIALS TYDOM
-            TYDOM_MAC = data['TYDOM_MAC']  # MAC Address of Tydom Box
-            if data['TYDOM_IP'] != '':
-                # , 'mediation.tydom.com') # Local ip address, default to mediation.tydom.com for remote connexion if not specified
-                TYDOM_IP = data['TYDOM_IP']
+            if data["TYDOM_MAC"] != "":
+                TYDOM_MAC = data["TYDOM_MAC"]  # MAC Address of Tydom Box
+            else:
+                logger.error("No Tydom MAC set")
+                exit()
 
-            TYDOM_PASSWORD = data['TYDOM_PASSWORD']  # Tydom password
-            TYDOM_ALARM_PIN = data['TYDOM_ALARM_PIN']
+            if data["TYDOM_IP"] != "":
+                TYDOM_IP = data["TYDOM_IP"]
 
-            TYDOM_ALARM_HOME_ZONE = data['TYDOM_ALARM_HOME_ZONE']
-            TYDOM_ALARM_NIGHT_ZONE = data['TYDOM_ALARM_NIGHT_ZONE']
+            if data["TYDOM_PASSWORD"] != "":
+                TYDOM_PASSWORD = data["TYDOM_PASSWORD"]  # Tydom password
+            else:
+                logger.error("No Tydom password set")
+                exit()
+
+            if data["TYDOM_ALARM_PIN"] != "":
+                TYDOM_ALARM_PIN = data["TYDOM_ALARM_PIN"]
+
+            if data["TYDOM_ALARM_HOME_ZONE"] != "":
+                TYDOM_ALARM_HOME_ZONE = data["TYDOM_ALARM_HOME_ZONE"]
+            if data["TYDOM_ALARM_NIGHT_ZONE"] != "":
+                TYDOM_ALARM_NIGHT_ZONE = data["TYDOM_ALARM_NIGHT_ZONE"]
 
             # CREDENTIALS MQTT
-            if data['MQTT_HOST'] != '':
-                MQTT_HOST = data['MQTT_HOST']
+            if data["MQTT_HOST"] != "":
+                MQTT_HOST = data["MQTT_HOST"]
 
-            if data['MQTT_USER'] != '':
-                MQTT_USER = data['MQTT_USER']
+            if data["MQTT_USER"] != "":
+                MQTT_USER = data["MQTT_USER"]
 
-            if data['MQTT_PASSWORD'] != '':
-                MQTT_PASSWORD = data['MQTT_PASSWORD']
+            if data["MQTT_PASSWORD"] != "":
+                MQTT_PASSWORD = data["MQTT_PASSWORD"]
 
-            if data['MQTT_PORT'] != 1883:
-                MQTT_PORT = data['MQTT_PORT']
+            if data["MQTT_PORT"] != 1883:
+                MQTT_PORT = data["MQTT_PORT"]
 
-            if (data['MQTT_SSL'] == 'true') or (data['MQTT_SSL']):
+            if (data["MQTT_SSL"] == "true") or (data["MQTT_SSL"]):
                 MQTT_SSL = True
 
         except Exception as e:
-            logger.error('Parsing error %s', e)
+            logger.error("Parsing error %s", e)
 
 except FileNotFoundError:
-    logger.info("No /data/options.json, seems we are not in hassio addon mode.")
+    logger.info(f"No {data_options_path}, seems we are not in hassio addon mode.")
     # CREDENTIALS TYDOM
-    TYDOM_MAC = os.getenv('TYDOM_MAC')  # MAC Address of Tydom Box
+    TYDOM_MAC = os.getenv("TYDOM_MAC")  # MAC Address of Tydom Box
     # Local ip address, default to mediation.tydom.com for remote connexion if
     # not specified
-    TYDOM_IP = os.getenv('TYDOM_IP', 'mediation.tydom.com')
-    TYDOM_PASSWORD = os.getenv('TYDOM_PASSWORD')  # Tydom password
-    TYDOM_ALARM_PIN = os.getenv('TYDOM_ALARM_PIN')
-    TYDOM_ALARM_HOME_ZONE = os.getenv('TYDOM_ALARM_HOME_ZONE', 1)
-    TYDOM_ALARM_NIGHT_ZONE = os.getenv('TYDOM_ALARM_NIGHT_ZONE', 2)
+    TYDOM_IP = os.getenv("TYDOM_IP", "mediation.tydom.com")
+    TYDOM_PASSWORD = os.getenv("TYDOM_PASSWORD")  # Tydom password
+    TYDOM_ALARM_PIN = os.getenv("TYDOM_ALARM_PIN")
+    TYDOM_ALARM_HOME_ZONE = os.getenv("TYDOM_ALARM_HOME_ZONE", 1)
+    TYDOM_ALARM_NIGHT_ZONE = os.getenv("TYDOM_ALARM_NIGHT_ZONE", 2)
 
     # CREDENTIALS MQTT
-    MQTT_HOST = os.getenv('MQTT_HOST', 'localhost')
-    MQTT_USER = os.getenv('MQTT_USER', '')
-    MQTT_PASSWORD = os.getenv('MQTT_PASSWORD', '')
+    MQTT_HOST = os.getenv("MQTT_HOST", "localhost")
+    MQTT_USER = os.getenv("MQTT_USER", "")
+    MQTT_PASSWORD = os.getenv("MQTT_PASSWORD", "")
 
     # 1883 #1884 for websocket without SSL
-    MQTT_PORT = os.getenv('MQTT_PORT', 1883)
-    MQTT_SSL = os.getenv('MQTT_SSL', False)
+    MQTT_PORT = os.getenv("MQTT_PORT", 1883)
+    MQTT_SSL = os.getenv("MQTT_SSL", False)
 
 
 tydom_client = TydomWebSocketClient(
-    mac=TYDOM_MAC,
-    host=TYDOM_IP,
-    password=TYDOM_PASSWORD,
-    alarm_pin=TYDOM_ALARM_PIN)
+    mac=TYDOM_MAC, host=TYDOM_IP, password=TYDOM_PASSWORD, alarm_pin=TYDOM_ALARM_PIN
+)
 hassio = MQTT_Hassio(
     broker_host=MQTT_HOST,
     port=MQTT_PORT,
@@ -116,11 +130,12 @@ hassio = MQTT_Hassio(
     mqtt_ssl=MQTT_SSL,
     home_zone=TYDOM_ALARM_HOME_ZONE,
     night_zone=TYDOM_ALARM_NIGHT_ZONE,
-    tydom=tydom_client)
+    tydom=tydom_client,
+)
 
 
 def loop_task():
-    logger.info('Starting main loop_task')
+    logger.info("Starting main loop_task")
     loop = asyncio.get_event_loop()
     loop.run_until_complete(hassio.connect())
 
@@ -132,9 +147,9 @@ def loop_task():
 
 
 async def listen_tydom_forever(tydom_client):
-    '''
-        Connect, then receive all server messages and pipe them to the handler, and reconnects if needed
-    '''
+    """
+    Connect, then receive all server messages and pipe them to the handler, and reconnects if needed
+    """
 
     while True:
         await asyncio.sleep(0)
@@ -147,49 +162,67 @@ async def listen_tydom_forever(tydom_client):
             while True:
                 # listener loop
                 try:
-                    incoming_bytes_str = await asyncio.wait_for(tydom_client.connection.recv(), timeout=tydom_client.refresh_timeout)
-                    logger.debug('<<<<<<<<<< Receiving from tydom_client...')
+                    incoming_bytes_str = await asyncio.wait_for(
+                        tydom_client.connection.recv(),
+                        timeout=tydom_client.refresh_timeout,
+                    )
+                    logger.debug("<<<<<<<<<< Receiving from tydom_client...")
                     logger.debug(incoming_bytes_str)
 
-                except (asyncio.TimeoutError, websockets.exceptions.ConnectionClosed) as e:
+                except (
+                    asyncio.TimeoutError,
+                    websockets.exceptions.ConnectionClosed,
+                ) as e:
                     logger.debug(e)
                     try:
                         pong = tydom_client.post_refresh()
-                        await asyncio.wait_for(pong, timeout=tydom_client.refresh_timeout)
+                        await asyncio.wait_for(
+                            pong, timeout=tydom_client.refresh_timeout
+                        )
                         # logger.debug('Ping OK, keeping connection alive...')
                         continue
                     except Exception as e:
                         logger.error(
-                            'TimeoutError or websocket error - retrying connection in %s seconds...'.format(
-                                tydom_client.sleep_time))
-                        logger.error('Error: %s', e)
+                            "TimeoutError or websocket error - retrying connection in %s seconds...".format(
+                                tydom_client.sleep_time
+                            )
+                        )
+                        logger.error("Error: %s", e)
                         await asyncio.sleep(tydom_client.sleep_time)
                         break
-                logger.debug('Server said > %s'.format(incoming_bytes_str))
+                logger.debug("Server said > %s".format(incoming_bytes_str))
                 incoming_bytes_str
 
                 handler = TydomMessageHandler(
                     incoming_bytes=incoming_bytes_str,
                     tydom_client=tydom_client,
-                    mqtt_client=hassio)
+                    mqtt_client=hassio,
+                )
                 try:
                     await handler.incomingTriage()
                 except Exception as e:
-                    logger.error('Tydom Message Handler exception : %s', e)
+                    logger.error("Tydom Message Handler exception : %s", e)
 
         except socket.gaierror:
             logger.info(
-                'Socket error - retrying connection in %s sec (Ctrl-C to quit)'.format(
-                    tydom_client.sleep_time))
+                "Socket error - retrying connection in %s sec (Ctrl-C to quit)".format(
+                    tydom_client.sleep_time
+                )
+            )
             await asyncio.sleep(tydom_client.sleep_time)
             continue
         except ConnectionRefusedError:
-            logger.error('Nobody seems to listen to this endpoint. Please check the URL.')
             logger.error(
-                'Retrying connection in %s sec (Ctrl-C to quit)'.format(tydom_client.sleep_time))
+                "Nobody seems to listen to this endpoint. Please check the URL."
+            )
+            logger.error(
+                "Retrying connection in %s sec (Ctrl-C to quit)".format(
+                    tydom_client.sleep_time
+                )
+            )
             await asyncio.sleep(tydom_client.sleep_time)
             continue
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     loop_task()

--- a/app/main.py
+++ b/app/main.py
@@ -81,7 +81,7 @@ try:
             logger.error('Parsing error %s', e)
 
 except FileNotFoundError:
-    logger.info("No /data/options.json, seems where are not in hassio addon mode.")
+    logger.info("No /data/options.json, seems we are not in hassio addon mode.")
     # CREDENTIALS TYDOM
     TYDOM_MAC = os.getenv('TYDOM_MAC')  # MAC Address of Tydom Box
     # Local ip address, default to mediation.tydom.com for remote connexion if
@@ -148,7 +148,7 @@ async def listen_tydom_forever(tydom_client):
                 try:
                     incoming_bytes_str = await asyncio.wait_for(tydom_client.connection.recv(), timeout=tydom_client.refresh_timeout)
                     logger.debug('<<<<<<<<<< Receiving from tydom_client...')
-                    # logger.debug(incoming_bytes_str)
+                    logger.debug(incoming_bytes_str)
 
                 except (asyncio.TimeoutError, websockets.exceptions.ConnectionClosed) as e:
                     logger.debug(e)
@@ -164,7 +164,7 @@ async def listen_tydom_forever(tydom_client):
                         logger.error('Error: %s', e)
                         await asyncio.sleep(tydom_client.sleep_time)
                         break
-                # logger.debug('Server said > %s'.format(incoming_bytes_str))
+                logger.debug('Server said > %s'.format(incoming_bytes_str))
                 incoming_bytes_str
 
                 handler = TydomMessageHandler(

--- a/app/mqtt_client.py
+++ b/app/mqtt_client.py
@@ -125,7 +125,8 @@ class MQTT_Hassio():
             endpoint_id = (get_id.split("_"))[1]  # extract id from mqtt
 
             logger.info("%s %s %s", str(get_id), 'positionCmd', value)
-            await Cover.put_positionCmd(tydom_client=self.tydom, device_id=device_id, cover_id=endpoint_id, positionCmd=str(value))
+            await Cover.put_positionCmd(tydom_client=self.tydom, device_id=device_id, cover_id=endpoint_id,
+                                        positionCmd=str(value))
 
         elif ('set_position' in str(topic)) and not ('set_positionCmd' in str(topic)):
 
@@ -139,7 +140,8 @@ class MQTT_Hassio():
             device_id = (get_id.split("_"))[0]  # extract id from mqtt
             endpoint_id = (get_id.split("_"))[1]  # extract id from mqtt
 
-            await Cover.put_position(tydom_client=self.tydom, device_id=device_id, cover_id=endpoint_id, position=str(value))
+            await Cover.put_position(tydom_client=self.tydom, device_id=device_id, cover_id=endpoint_id,
+                                     position=str(value))
 
         elif 'set_levelCmd' in str(topic):
             logger.info('Incoming MQTT set_levelCmd request : %s %s', topic, payload)
@@ -150,8 +152,8 @@ class MQTT_Hassio():
             endpoint_id = (get_id.split("_"))[1]  # extract id from mqtt
 
             logger.info("%s %s %s", str(get_id), 'levelCmd', value)
-            await Light.put_levelCmd(tydom_client=self.tydom, device_id=device_id, light_id=endpoint_id,
-                                     levelCmd=str(value))
+            await Light.put_level_cmd(tydom_client=self.tydom, device_id=device_id, light_id=endpoint_id,
+                                      level_cmd=str(value))
 
         elif ('set_level' in str(topic)) and not ('set_levelCmd' in str(topic)):
 
@@ -176,7 +178,8 @@ class MQTT_Hassio():
             device_id = (get_id.split("_"))[0]  # extract id from mqtt
             endpoint_id = (get_id.split("_"))[1]  # extract id from mqtt
 
-            await Alarm.put_alarm_state(tydom_client=self.tydom, device_id=device_id, alarm_id=endpoint_id, asked_state=command, home_zone=self.home_zone, night_zone=self.night_zone)
+            await Alarm.put_alarm_state(tydom_client=self.tydom, device_id=device_id, alarm_id=endpoint_id,
+                                        asked_state=command, home_zone=self.home_zone, night_zone=self.night_zone)
 
         elif ('set_setpoint' in str(topic)):
 
@@ -191,7 +194,7 @@ class MQTT_Hassio():
             await Boiler.put_temperature(tydom_client=self.tydom, device_id=device_id, boiler_id=endpoint_id,
                                          set_setpoint=str(value))
 
-        elif ('set_hvacMode' in str(topic)):
+        elif 'set_hvacMode' in str(topic):
 
             value = str(payload).strip('b').strip("'")
             logger.info('Incoming MQTT set_hvacMode request : %s %s', topic, value)
@@ -200,8 +203,8 @@ class MQTT_Hassio():
             device_id = (get_id.split("_"))[0]  # extract id from mqtt
             endpoint_id = (get_id.split("_"))[1]  # extract id from mqtt
 
-            await Boiler.put_hvacMode(tydom_client=self.tydom, device_id=device_id, boiler_id=endpoint_id,
-                                      set_hvacMode=str(value))
+            await Boiler.put_hvac_mode(tydom_client=self.tydom, device_id=device_id, boiler_id=endpoint_id,
+                                       set_hvac_mode=str(value))
 
         elif ('set_thermicLevel' in str(topic)):
 
@@ -212,8 +215,8 @@ class MQTT_Hassio():
             device_id = (get_id.split("_"))[0]  # extract id from mqtt
             endpoint_id = (get_id.split("_"))[1]  # extract id from mqtt
 
-            await Boiler.put_thermicLevel(tydom_client=self.tydom, device_id=device_id, boiler_id=endpoint_id,
-                                          set_thermicLevel=str(value))
+            await Boiler.put_thermic_level(tydom_client=self.tydom, device_id=device_id, boiler_id=endpoint_id,
+                                           set_thermic_level=str(value))
         elif ('set_switch_state' in str(topic)) and not ('homeassistant' in str(topic)):
             # logger.debug("%s %s %s %s", topic, payload, qos, properties)
             command = str(payload).strip('b').strip("'")
@@ -222,6 +225,7 @@ class MQTT_Hassio():
             device_id = (get_id.split("_"))[0]  # extract id from mqtt
             endpoint_id = (get_id.split("_"))[1]  # extract id from mqtt
 
+            # This seems broken, but I'm not entirely clear what it is *meant* to do?
             await Switch.put_switch_state(tydom_client=self.tydom, device_id=device_id, switch_id=endpoint_id, state=command)
 
         elif 'set_levelCmdGate' in str(topic):
@@ -233,8 +237,8 @@ class MQTT_Hassio():
             endpoint_id = (get_id.split("_"))[1]  # extract id from mqtt
 
             logger.info("%s %s %s", str(get_id), 'levelCmd', value)
-            await Light.put_levelCmdGate(tydom_client=self.tydom, device_id=device_id, switch_id=endpoint_id,
-                                         levelCmd=str(value))
+            await Switch.put_level_cmd_gate(tydom_client=self.tydom, device_id=device_id, switch_id=endpoint_id,
+                                            level_cmd=str(value))
 
         elif ('set_levelGate' in str(topic)) and not ('set_levelCmd' in str(topic)):
 
@@ -248,8 +252,8 @@ class MQTT_Hassio():
             device_id = (get_id.split("_"))[0]  # extract id from mqtt
             endpoint_id = (get_id.split("_"))[1]  # extract id from mqtt
 
-            await Light.put_levelGate(tydom_client=self.tydom, device_id=device_id, switch_id=endpoint_id,
-                                      level=str(value))
+            await Switch.put_level_gate(tydom_client=self.tydom, device_id=device_id, switch_id=endpoint_id,
+                                        level=str(value))
 
         else:
             pass

--- a/app/switch.py
+++ b/app/switch.py
@@ -115,12 +115,14 @@ class Switch:
     # def __init__(self, name, elem_name, tydom_attributes_payload,
     # attributes_topic_from_device, mqtt=None):
 
-    async def put_levelGate(tydom_client, device_id, switch_id, level):
+    @staticmethod
+    async def put_level_gate(tydom_client, device_id, switch_id, level):
         logger.info("%s %s %s", switch_id, 'level', level)
         if not (level == ''):
             await tydom_client.put_devices_data(device_id, switch_id, 'level', level)
 
-    async def put_levelCmdGate(tydom_client, device_id, switch_id, levelCmd):
-        logger.info("%s %s %s", switch_id, 'levelCmd', levelCmd)
-        if not (levelCmd == ''):
-            await tydom_client.put_devices_data(device_id, switch_id, 'levelCmd', levelCmd)
+    @staticmethod
+    async def put_level_cmd_gate(tydom_client, device_id, switch_id, level_cmd):
+        logger.info("%s %s %s", switch_id, 'levelCmd', level_cmd)
+        if not (level_cmd == ''):
+            await tydom_client.put_devices_data(device_id, switch_id, 'levelCmd', level_cmd)

--- a/app/tydomConnector.py
+++ b/app/tydomConnector.py
@@ -22,11 +22,9 @@ logger = logging.getLogger(__name__)
 # https://stackoverflow.com/questions/49878953/issues-listening-incoming-messages-in-websocket-client-on-python-3-6
 
 
-class TydomWebSocketClient():
-
-    def __init__(self, mac, password, alarm_pin=None,
-                 host='mediation.tydom.com'):
-        logger.info('Initialising TydomClient Class')
+class TydomWebSocketClient:
+    def __init__(self, mac, password, alarm_pin=None, host="mediation.tydom.com"):
+        logger.info("Initialising TydomClient Class")
 
         self.password = password
         self.mac = mac
@@ -64,7 +62,7 @@ class TydomWebSocketClient():
 
         # Set Host, ssl context and prefix for remote or local connection
         if self.host == "mediation.tydom.com":
-            logger.info('Setting remote mode context.')
+            logger.info("Setting remote mode context.")
             self.remote_mode = True
             # self.ssl_context = None
             self.ssl_context = ssl._create_unverified_context()
@@ -72,7 +70,7 @@ class TydomWebSocketClient():
             self.ping_timeout = 40
 
         else:
-            logger.info('Setting local mode context.')
+            logger.info("Setting local mode context.")
             self.remote_mode = False
             self.ssl_context = ssl._create_unverified_context()
             self.cmd_prefix = ""
@@ -81,36 +79,38 @@ class TydomWebSocketClient():
     async def connect(self):
 
         logger.info('""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""')
-        logger.info('TYDOM WEBSOCKET CONNECTION INITIALISING....                     ')
+        logger.info("TYDOM WEBSOCKET CONNECTION INITIALISING....                     ")
 
-        logger.info('Building headers, getting 1st handshake and authentication....')
+        logger.info("Building headers, getting 1st handshake and authentication....")
 
-        http_headers = {"Connection": "Upgrade",
-                        "Upgrade": "websocket",
-                        "Host": self.host + ":443",
-                        "Accept": "*/*",
-                        "Sec-WebSocket-Key": self.generate_random_key(),
-                        "Sec-WebSocket-Version": "13"
-                        }
-        conn = http.client.HTTPSConnection(
-            self.host, 443, context=self.ssl_context)
+        http_headers = {
+            "Connection": "Upgrade",
+            "Upgrade": "websocket",
+            "Host": self.host + ":443",
+            "Accept": "*/*",
+            "Sec-WebSocket-Key": self.generate_random_key(),
+            "Sec-WebSocket-Version": "13",
+        }
+        conn = http.client.HTTPSConnection(self.host, 443, context=self.ssl_context)
 
         # Get first handshake
-        conn.request("GET",
-                     "/mediation/client?mac={}&appli=1".format(self.mac),
-                     None,
-                     http_headers)
+        conn.request(
+            "GET",
+            "/mediation/client?mac={}&appli=1".format(self.mac),
+            None,
+            http_headers,
+        )
         res = conn.getresponse()
         # Close HTTPS Connection
         conn.close()
 
-        logger.debug('response headers')
+        logger.debug("response headers")
         logger.debug(res.headers)
-        logger.debug('response code')
+        logger.debug("response code")
         logger.debug(res.getcode())
 
         # read response
-        logger.debug('response')
+        logger.debug("response")
         logger.debug(res.read())
         res.read()
 
@@ -122,13 +122,13 @@ class TydomWebSocketClient():
         try:
             # Anecdotally, local installations are unauthenticated but we don't *know* that for certain
             # so we'll EAFP, try to use the header and fallback if we're unable.
-            nonce = res.headers["WWW-Authenticate"].split(',', 3)
+            nonce = res.headers["WWW-Authenticate"].split(",", 3)
             # Build websocket headers
-            websocket_headers = {'Authorization': self.build_digest_headers(nonce)}
+            websocket_headers = {"Authorization": self.build_digest_headers(nonce)}
         except AttributeError:
             pass
 
-        logger.info('Upgrading http connection to websocket....')
+        logger.info("Upgrading http connection to websocket....")
 
         if self.ssl_context is not None:
             websocket_ssl_context = self.ssl_context
@@ -136,22 +136,33 @@ class TydomWebSocketClient():
             websocket_ssl_context = True  # Verify certificate
 
         # outer loop restarted every time the connection fails
-        logger.info('Attempting websocket connection with tydom hub.......................')
-        logger.info('Host Target : %s', self.host)
-        '''
+        logger.info(
+            "Attempting websocket connection with tydom hub......................."
+        )
+        logger.info("Host Target : %s", self.host)
+        """
             Connecting to webSocket server
             websockets.client.connect returns a WebSocketClientProtocol, which is used to send and receive messages
-        '''
+        """
         try:
             self.connection = await websockets.connect(
-                'wss://{}:443/mediation/client?mac={}&appli=1'.format(self.host, self.mac),
-                extra_headers=websocket_headers, ssl=websocket_ssl_context, ping_timeout=None)
+                "wss://{}:443/mediation/client?mac={}&appli=1".format(
+                    self.host, self.mac
+                ),
+                extra_headers=websocket_headers,
+                ssl=websocket_ssl_context,
+                ping_timeout=None,
+            )
 
             return self.connection
         except Exception as e:
-            logger.error('Exception when trying to connect with websocket !')
+            logger.error("Exception when trying to connect with websocket !")
             logger.error(e)
-            logger.error('wss://{}:443/mediation/client?mac={}&appli=1'.format(self.host, self.mac))
+            logger.error(
+                "wss://{}:443/mediation/client?mac={}&appli=1".format(
+                    self.host, self.mac
+                )
+            )
             logger.error(websocket_headers)
             exit()
 
@@ -173,9 +184,13 @@ class TydomWebSocketClient():
         digest_auth._thread_local.last_nonce = nonce
         digest_auth._thread_local.nonce_count = 1
         return digest_auth.build_digest_header(
-            'GET', "https://{}:443/mediation/client?mac={}&appli=1".format(self.host, self.mac))
+            "GET",
+            "https://{}:443/mediation/client?mac={}&appli=1".format(
+                self.host, self.mac
+            ),
+        )
 
-    async def notify_alive(self, msg='OK'):
+    async def notify_alive(self, msg="OK"):
         # logger.info('Connection Still Alive !')
         pass
         # if self.sys_context == 'systemd':
@@ -195,16 +210,20 @@ class TydomWebSocketClient():
     async def send_message(self, method, msg):
         # logger.debug("%s %s", method, msg)
 
-        str = self.cmd_prefix + method + ' ' + msg + \
-              " HTTP/1.1\r\nContent-Length: 0\r\nContent-Type: application/json; charset=UTF-8\r\nTransac-Id: 0\r\n\r\n"
+        str = (
+            self.cmd_prefix
+            + method
+            + " "
+            + msg
+            + " HTTP/1.1\r\nContent-Length: 0\r\nContent-Type: application/json; charset=UTF-8\r\nTransac-Id: 0\r\n\r\n"
+        )
         a_bytes = bytes(str, "ascii")
-        if 'pwd' not in msg:
-            logger.info('>>>>>>>>>> Sending to tydom client..... %s %s', method, msg)
+        if "pwd" not in msg:
+            logger.info(">>>>>>>>>> Sending to tydom client..... %s %s", method, msg)
         else:
             logger.info(
-                '>>>>>>>>>> Sending to tydom client..... %s %s',
-                method,
-                'secret msg')
+                ">>>>>>>>>> Sending to tydom client..... %s %s", method, "secret msg"
+            )
 
         await self.connection.send(a_bytes)
         # logger.debug(a_bytes)
@@ -214,16 +233,22 @@ class TydomWebSocketClient():
     async def put_devices_data(self, device_id, endpoint_id, name, value):
 
         # For shutter, value is the percentage of closing
-        body = "[{\"name\":\"" + name + "\",\"value\":\"" + value + "\"}]"
+        body = '[{"name":"' + name + '","value":"' + value + '"}]'
         # endpoint_id is the endpoint = the device (shutter in this case) to
         # open.
-        str_request = self.cmd_prefix + "PUT /devices/{}/endpoints/{}/data HTTP/1.1\r\nContent-Length: ".format(
-            str(device_id), str(
-                endpoint_id)) + str(
-            len(body)) + "\r\nContent-Type: application/json; charset=UTF-8\r\nTransac-Id: 0\r\n\r\n" + body + "\r\n\r\n"
+        str_request = (
+            self.cmd_prefix
+            + "PUT /devices/{}/endpoints/{}/data HTTP/1.1\r\nContent-Length: ".format(
+                str(device_id), str(endpoint_id)
+            )
+            + str(len(body))
+            + "\r\nContent-Type: application/json; charset=UTF-8\r\nTransac-Id: 0\r\n\r\n"
+            + body
+            + "\r\n\r\n"
+        )
         a_bytes = bytes(str_request, "ascii")
         # logger.debug(a_bytes)
-        logger.info('Sending to tydom client..... %s %s', 'PUT data', body)
+        logger.info("Sending to tydom client..... %s %s", "PUT data", body)
         await self.connection.send(a_bytes)
         return 0
 
@@ -245,91 +270,105 @@ class TydomWebSocketClient():
         # zones
 
         if self.alarm_pin is None:
-            logger.warn('TYDOM_ALARM_PIN not set !')
+            logger.warn("TYDOM_ALARM_PIN not set !")
             pass
         try:
 
             if zone_id is None:
-                cmd = 'alarmCmd'
-                body = "{\"value\":\"" + \
-                       str(value) + "\",\"pwd\":\"" + str(self.alarm_pin) + "\"}"
+                cmd = "alarmCmd"
+                body = (
+                    '{"value":"' + str(value) + '","pwd":"' + str(self.alarm_pin) + '"}'
+                )
                 # body= {"value":"OFF","pwd":"123456"}
             else:
-                cmd = 'zoneCmd'
-                body = "{\"value\":\"" + str(value) + "\",\"pwd\":\"" + str(
-                    self.alarm_pin) + "\",\"zones\":\"[" + str(zone_id) + "]\"}"
+                cmd = "zoneCmd"
+                body = (
+                    '{"value":"'
+                    + str(value)
+                    + '","pwd":"'
+                    + str(self.alarm_pin)
+                    + '","zones":"['
+                    + str(zone_id)
+                    + ']"}'
+                )
 
             # str_request = self.cmd_prefix + "PUT /devices/{}/endpoints/{}/cdata?name={},".format(str(alarm_id),str(alarm_id),str(cmd)) + body +");"
-            str_request = self.cmd_prefix + "PUT /devices/{}/endpoints/{}/cdata?name={} HTTP/1.1\r\nContent-Length: ".format(
-                str(device_id), str(
-                    alarm_id), str(cmd)) + str(
-                len(body)) + "\r\nContent-Type: application/json; charset=UTF-8\r\nTransac-Id: 0\r\n\r\n" + body + "\r\n\r\n"
+            str_request = (
+                self.cmd_prefix
+                + "PUT /devices/{}/endpoints/{}/cdata?name={} HTTP/1.1\r\nContent-Length: ".format(
+                    str(device_id), str(alarm_id), str(cmd)
+                )
+                + str(len(body))
+                + "\r\nContent-Type: application/json; charset=UTF-8\r\nTransac-Id: 0\r\n\r\n"
+                + body
+                + "\r\n\r\n"
+            )
 
             a_bytes = bytes(str_request, "ascii")
             # logger.debug(a_bytes)
-            logger.info('Sending to tydom client..... %s %s', 'PUT cdata', body)
+            logger.info("Sending to tydom client..... %s %s", "PUT cdata", body)
 
             await self.connection.send(a_bytes)
             return 0
         except Exception as e:
-            logger.error('put_alarm_cdata ERROR !')
+            logger.error("put_alarm_cdata ERROR !")
             logger.error(e)
             logger.error(a_bytes)
 
     # Get some information on Tydom
 
     async def get_info(self):
-        msg_type = '/info'
-        req = 'GET'
+        msg_type = "/info"
+        req = "GET"
         await self.send_message(method=req, msg=msg_type)
 
     # Refresh (all)
     async def post_refresh(self):
 
         # logger.info("Refresh....")
-        msg_type = '/refresh/all'
-        req = 'POST'
+        msg_type = "/refresh/all"
+        req = "POST"
         await self.send_message(method=req, msg=msg_type)
 
     # Get the moments (programs)
     async def get_moments(self):
-        msg_type = '/moments/file'
-        req = 'GET'
+        msg_type = "/moments/file"
+        req = "GET"
         await self.send_message(method=req, msg=msg_type)
 
     # Get the scenarios
     async def get_scenarii(self):
-        msg_type = '/scenarios/file'
-        req = 'GET'
+        msg_type = "/scenarios/file"
+        req = "GET"
         await self.send_message(method=req, msg=msg_type)
 
     # Get a ping (pong should be returned)
 
     async def get_ping(self):
-        msg_type = '/ping'
-        req = 'GET'
+        msg_type = "/ping"
+        req = "GET"
         await self.send_message(method=req, msg=msg_type)
-        logger.info('****** ping !')
+        logger.info("****** ping !")
 
     # Get all devices metadata
 
     async def get_devices_meta(self):
-        msg_type = '/devices/meta'
-        req = 'GET'
+        msg_type = "/devices/meta"
+        req = "GET"
         await self.send_message(method=req, msg=msg_type)
 
     # Get all devices data
 
     async def get_devices_data(self):
-        msg_type = '/devices/data'
-        req = 'GET'
+        msg_type = "/devices/data"
+        req = "GET"
         await self.send_message(method=req, msg=msg_type)
 
     # List the device to get the endpoint id
 
     async def get_configs_file(self):
-        msg_type = '/configs/file'
-        req = 'GET'
+        msg_type = "/configs/file"
+        req = "GET"
         await self.send_message(method=req, msg=msg_type)
 
     async def get_data(self):
@@ -340,9 +379,12 @@ class TydomWebSocketClient():
     # Give order to endpoint
     async def get_device_data(self, id):
         # 10 here is the endpoint = the device (shutter in this case) to open.
-        str_request = self.cmd_prefix + \
-                      "GET /devices/{}/endpoints/{}/data HTTP/1.1\r\nContent-Length: 0\r\nContent-Type: application/json; charset=UTF-8\r\nTransac-Id: 0\r\n\r\n".format(
-                          str(id), str(id))
+        str_request = (
+            self.cmd_prefix
+            + "GET /devices/{}/endpoints/{}/data HTTP/1.1\r\nContent-Length: 0\r\nContent-Type: application/json; charset=UTF-8\r\nTransac-Id: 0\r\n\r\n".format(
+                str(id), str(id)
+            )
+        )
         a_bytes = bytes(str_request, "ascii")
         await self.connection.send(a_bytes)
         # name = await self.recv()
@@ -353,7 +395,7 @@ class TydomWebSocketClient():
         Sending heartbeat to server
         Ping - pong messages to verify connection is alive adn data is always up to date
         """
-        logger.info('Requesting 1st data...')
+        logger.info("Requesting 1st data...")
         await self.get_info()
         logger.info("##################################")
         logger.info("##################################")

--- a/app/tydomConnector.py
+++ b/app/tydomConnector.py
@@ -302,12 +302,14 @@ class TydomWebSocketClient:
             # logger.debug(a_bytes)
             logger.info("Sending to tydom client..... %s %s", "PUT cdata", body)
 
-            await self.connection.send(a_bytes)
-            return 0
-        except Exception as e:
-            logger.error("put_alarm_cdata ERROR !")
-            logger.error(e)
-            logger.error(a_bytes)
+            try:
+                await self.connection.send(a_bytes)
+                return 0
+            except:
+                logger.error("put_alarm_cdata ERROR !", exc_info=True)
+                logger.error(a_bytes)
+        except:
+            logger.error("put_alarm_cdata ERROR !", exc_info=True)
 
     # Get some information on Tydom
 

--- a/app/tydomConnector.py
+++ b/app/tydomConnector.py
@@ -146,9 +146,7 @@ class TydomWebSocketClient:
         """
         try:
             self.connection = await websockets.connect(
-                "wss://{}:443/mediation/client?mac={}&appli=1".format(
-                    self.host, self.mac
-                ),
+                f"wss://{self.host}:443/mediation/client?mac={self.mac}&appli=1",
                 extra_headers=websocket_headers,
                 ssl=websocket_ssl_context,
                 ping_timeout=None,
@@ -159,9 +157,7 @@ class TydomWebSocketClient:
             logger.error("Exception when trying to connect with websocket !")
             logger.error(e)
             logger.error(
-                "wss://{}:443/mediation/client?mac={}&appli=1".format(
-                    self.host, self.mac
-                )
+                f"wss://{self.host}:443/mediation/client?mac={self.mac}&appli=1"
             )
             logger.error(websocket_headers)
             exit()
@@ -185,8 +181,8 @@ class TydomWebSocketClient:
         digest_auth._thread_local.nonce_count = 1
         return digest_auth.build_digest_header(
             "GET",
-            "https://{}:443/mediation/client?mac={}&appli=1".format(
-                self.host, self.mac
+            "https://{host}:443/mediation/client?mac={mac}&appli=1".format(
+                host=self.host, mac=self.mac
             ),
         )
 
@@ -238,9 +234,7 @@ class TydomWebSocketClient:
         # open.
         str_request = (
             self.cmd_prefix
-            + "PUT /devices/{}/endpoints/{}/data HTTP/1.1\r\nContent-Length: ".format(
-                str(device_id), str(endpoint_id)
-            )
+            + f"PUT /devices/{device_id}/endpoints/{endpoint_id}/data HTTP/1.1\r\nContent-Length: "
             + str(len(body))
             + "\r\nContent-Type: application/json; charset=UTF-8\r\nTransac-Id: 0\r\n\r\n"
             + body
@@ -295,8 +289,8 @@ class TydomWebSocketClient:
             # str_request = self.cmd_prefix + "PUT /devices/{}/endpoints/{}/cdata?name={},".format(str(alarm_id),str(alarm_id),str(cmd)) + body +");"
             str_request = (
                 self.cmd_prefix
-                + "PUT /devices/{}/endpoints/{}/cdata?name={} HTTP/1.1\r\nContent-Length: ".format(
-                    str(device_id), str(alarm_id), str(cmd)
+                + "PUT /devices/{device}/endpoints/{alarm}/cdata?name={cmd} HTTP/1.1\r\nContent-Length: ".format(
+                    device=str(device_id), alarm=str(alarm_id), cmd=str(cmd)
                 )
                 + str(len(body))
                 + "\r\nContent-Type: application/json; charset=UTF-8\r\nTransac-Id: 0\r\n\r\n"
@@ -379,11 +373,10 @@ class TydomWebSocketClient:
     # Give order to endpoint
     async def get_device_data(self, id):
         # 10 here is the endpoint = the device (shutter in this case) to open.
+        device_id = str(id)
         str_request = (
             self.cmd_prefix
-            + "GET /devices/{}/endpoints/{}/data HTTP/1.1\r\nContent-Length: 0\r\nContent-Type: application/json; charset=UTF-8\r\nTransac-Id: 0\r\n\r\n".format(
-                str(id), str(id)
-            )
+            + f"GET /devices/{device_id}/endpoints/{device_id}/data HTTP/1.1\r\nContent-Length: 0\r\nContent-Type: application/json; charset=UTF-8\r\nTransac-Id: 0\r\n\r\n"
         )
         a_bytes = bytes(str_request, "ascii")
         await self.connection.send(a_bytes)

--- a/app/tydomConnector.py
+++ b/app/tydomConnector.py
@@ -101,14 +101,24 @@ class TydomWebSocketClient():
                      None,
                      httpHeaders)
         res = conn.getresponse()
-        logger.info('response')
-        logger.info(res)
-        # Get authentication
-        nonce = res.headers["WWW-Authenticate"].split(',', 3)
-        # read response
-        res.read()
         # Close HTTPS Connection
         conn.close()
+
+        logger.debug('response headers')
+        logger.debug(res.headers)
+        logger.debug('response code')
+        logger.debug(res.getcode())
+
+        # read response
+        logger.debug('response')
+        logger.debug(res.read())
+        res.read()
+
+        # if res.getcode() is not 101:
+        #     exit('Was not able to continue')
+
+        # Get authentication
+        nonce = "" #res.headers["WWW-Authenticate"].split(',', 3)
 
         logger.info('Upgrading http connection to websocket....')
         # Build websocket headers
@@ -149,7 +159,7 @@ class TydomWebSocketClient():
     def build_digest_headers(self, nonce):
         digestAuth = HTTPDigestAuth(self.mac, self.password)
         chal = dict()
-        chal["nonce"] = nonce[2].split('=', 1)[1].split('"')[1]
+        chal["nonce"] = "" # nonce[2].split('=', 1)[1].split('"')[1]
         chal["realm"] = "ServiceMedia" if self.remote_mode is True else "protected area"
         chal["qop"] = "auth"
         digestAuth._thread_local.chal = chal

--- a/app/tydomConnector.py
+++ b/app/tydomConnector.py
@@ -101,6 +101,8 @@ class TydomWebSocketClient():
                      None,
                      httpHeaders)
         res = conn.getresponse()
+        logger.info('response')
+        logger.info(res)
         # Get authentication
         nonce = res.headers["WWW-Authenticate"].split(',', 3)
         # read response

--- a/app/tydomMessagehandler.py
+++ b/app/tydomMessagehandler.py
@@ -292,10 +292,12 @@ class TydomMessageHandler():
                 logger.debug(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")
                 logger.debug('Incoming message type : config detected')
                 msg_type = 'msg_config'
+                logger.debug(data)
             elif ("id" in first):
                 logger.debug(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")
                 logger.debug('Incoming message type : data detected')
                 msg_type = 'msg_data'
+                logger.debug(data)
             elif ("doctype" in first):
                 logger.debug('Incoming message type : html detected (probable 404)')
                 msg_type = 'msg_html'
@@ -304,7 +306,7 @@ class TydomMessageHandler():
                 logger.debug(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")
                 logger.debug('Incoming message type : Info detected')
                 msg_type = 'msg_info'
-                # logger.debug(data)
+                logger.debug(data)
             else:
                 logger.debug('Incoming message type : no type detected')
                 logger.debug(data)

--- a/app/tydomMessagehandler.py
+++ b/app/tydomMessagehandler.py
@@ -401,15 +401,15 @@ class TydomMessageHandler():
                         name_of_id = self.get_name_from_id(unique_id)
                         type_of_id = self.get_type_from_id(unique_id)
 
-                        _LOGGER.debug("======[ DEVICE INFOS ]======")
-                        _LOGGER.debug("ID {}".format(device_id))
-                        _LOGGER.debug("ENDPOINT ID {}".format(endpoint_id))
-                        _LOGGER.debug("Name {}".format(name_of_id))
-                        _LOGGER.debug("Type {}".format(type_of_id))
-                        _LOGGER.debug("==========================")
+                        logger.debug("======[ DEVICE INFOS ]======")
+                        logger.debug("ID {}".format(device_id))
+                        logger.debug("ENDPOINT ID {}".format(endpoint_id))
+                        logger.debug("Name {}".format(name_of_id))
+                        logger.debug("Type {}".format(type_of_id))
+                        logger.debug("==========================")
 
                         for elem in endpoint["data"]:
-                            _LOGGER.debug("CURRENT ELEM={}".format(elem))
+                            logger.debug("CURRENT ELEM={}".format(elem))
                             # endpoint_id = None
 
                             # Element name


### PR DESCRIPTION
This includes a bunch of Python formatting fixes (I highly recommend using [PyCharm](https://www.jetbrains.com/pycharm/download/#section=mac) and [Black](https://black.readthedocs.io/en/stable)).

- If the WWW-Authenticate header is not present, it doesn't try to use it and things should work. 
- The Tydom IP and MAC are required and will throw an error message before exiting if they are not provided.
- The Tydom Alarm PIN is no longer required.
- Static methods are actually static (thanks @dwrss)
- Some incorrect logger calls are no longer broken.
- The alarm should work now. It definitely did _not_ before.

Switches (specifically `set_switch_state`) definitely seem broken, but I don't have anything of those to test with so it's quite hard to find out what—as such, that's been left alone.