### PR TITLE
add 'awning' and 'other' support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .DS_Store
 app/.venv/
 .gitignore
+.vs/

--- a/app/tydom/MessageHandler.py
+++ b/app/tydom/MessageHandler.py
@@ -327,7 +327,8 @@ class MessageHandler:
                 "_" + str(i["id_device"])
 
             if i["last_usage"] == 'shutter' or i["last_usage"] == 'klineShutter' or i["last_usage"] == 'light' or i["last_usage"] == 'window' or i["last_usage"] == 'windowFrench' or i["last_usage"] == 'windowSliding' or i[
-                    "last_usage"] == 'belmDoor' or i["last_usage"] == 'klineDoor' or i["last_usage"] == 'klineWindowFrench' or i["last_usage"] == 'klineWindowSliding' or i["last_usage"] == 'garage_door' or i["last_usage"] == 'gate':
+                    "last_usage"] == 'belmDoor' or i["last_usage"] == 'klineDoor' or i["last_usage"] == 'klineWindowFrench' or i["last_usage"] == 'klineWindowSliding' or i["last_usage"] == 'garage_door' or i["last_usage"] == 'gate' or i[
+                        "last_usage"] == 'awning':
                 device_name[device_unique_id] = i["name"]
                 device_type[device_unique_id] = i["last_usage"]
                 device_endpoint[device_unique_id] = i["id_endpoint"]
@@ -452,7 +453,7 @@ class MessageHandler:
                                     attr_light['device_type'] = 'light'
                                     attr_light[element_name] = element_value
 
-                            if type_of_id == 'shutter' or type_of_id == 'klineShutter':
+                            if type_of_id == 'shutter' or type_of_id == 'awning' or type_of_id == 'klineShutter':
                                 if element_name in deviceCoverKeywords and element_validity == 'upToDate':
                                     attr_cover['device_id'] = device_id
                                     attr_cover['endpoint_id'] = endpoint_id

--- a/app/tydom/MessageHandler.py
+++ b/app/tydom/MessageHandler.py
@@ -328,7 +328,7 @@ class MessageHandler:
 
             if i["last_usage"] == 'shutter' or i["last_usage"] == 'klineShutter' or i["last_usage"] == 'light' or i["last_usage"] == 'window' or i["last_usage"] == 'windowFrench' or i["last_usage"] == 'windowSliding' or i[
                     "last_usage"] == 'belmDoor' or i["last_usage"] == 'klineDoor' or i["last_usage"] == 'klineWindowFrench' or i["last_usage"] == 'klineWindowSliding' or i["last_usage"] == 'garage_door' or i["last_usage"] == 'gate' or i[
-                        "last_usage"] == 'awning':
+                        "last_usage"] == 'awning' or i["last_usage"] == 'other':
                 device_name[device_unique_id] = i["name"]
                 device_type[device_unique_id] = i["last_usage"]
                 device_endpoint[device_unique_id] = i["id_endpoint"]
@@ -578,6 +578,22 @@ class MessageHandler:
                                     attr_ukn['device_type'] = 'sensor'
                                     attr_ukn['element_name'] = element_name
                                     attr_ukn[element_name] = element_value
+
+                            if type_of_id == 'other':
+                                if element_name in deviceLightKeywords and element_validity == 'upToDate':
+                                    attr_light['device_id'] = device_id
+                                    attr_light['endpoint_id'] = endpoint_id
+                                    attr_light['id'] = str(
+                                        device_id) + '_' + str(endpoint_id)
+                                    attr_light['light_name'] = print_id
+                                    attr_light['name'] = print_id
+                                    attr_light['device_type'] = 'light' # later replace with commented condition below
+                                    attr_light[element_name] = element_value
+
+                                    #if condition_to_define_light_or_switch:
+                                    #    attr_light['device_type'] = 'light'
+                                    #else:
+                                    #    attr_light['device_type'] = 'switch'
 
                     except Exception as e:
                         logger.error('msg_data error in parsing !')


### PR DESCRIPTION
This is simple additional support for shutters registered in tydom as awnings.
They are the same modules, working exactly the same way, they have just been categorized differently.

For 'others' devices, this is a support for 0-100 modules (light, on/off, variation, etc.), push buttons ahead.