### PR TITLE
fix update_sensors function not filtering correctly attr

### DIFF
--- a/app/sensors/Alarm.py
+++ b/app/sensors/Alarm.py
@@ -82,7 +82,7 @@ class Alarm:
 
     async def update_sensors(self):
         for i, j in self.attributes.items():
-            if not i == 'device_type' or not i == 'id':
+            if not i == 'device_type' and not i == 'id' and not i == 'device_id' and not i == 'endpoint_id':
                 new_sensor = Sensor(
                     elem_name=i,
                     tydom_attributes_payload=self.attributes,

--- a/app/sensors/Cover.py
+++ b/app/sensors/Cover.py
@@ -101,7 +101,7 @@ class Cover:
 
     async def update_sensors(self):
         for i, j in self.attributes.items():
-            if not i == 'device_type' or not i == 'id':
+            if not i == 'device_type' and not i == 'id' and not i == 'device_id' and not i == 'endpoint_id':
                 new_sensor = Sensor(
                     elem_name=i,
                     tydom_attributes_payload=self.attributes,

--- a/app/sensors/Light.py
+++ b/app/sensors/Light.py
@@ -86,7 +86,7 @@ class Light:
 
     async def update_sensors(self):
         for i, j in self.attributes.items():
-            if not i == 'device_type' or not i == 'id':
+            if not i == 'device_type' and not i == 'id' and not i == 'device_id' and not i == 'endpoint_id':
                 new_sensor = Sensor(
                     elem_name=i,
                     tydom_attributes_payload=self.attributes,

--- a/app/sensors/Switch.py
+++ b/app/sensors/Switch.py
@@ -85,7 +85,7 @@ class Switch:
 
     async def update_sensors(self):
         for i, j in self.attributes.items():
-            if not i == 'device_type' or not i == 'id':
+            if not i == 'device_type' and not i == 'id' and not i == 'device_id' and not i == 'endpoint_id':
                 new_sensor = Sensor(
                     elem_name=i,
                     tydom_attributes_payload=self.attributes,


### PR DESCRIPTION
Hello,
A fix for the update_sensors() function.
The conditions should be 'and' instead of 'or'.
Also filter device_id and endpoint_id, no need to push them as a sensor, they are available in json attributes topic.