### PR TITLE
Feature : Add custom presets for unmanaged device

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.autopep8"
+    },
+    "python.formatting.provider": "none"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "[python]": {
-        "editor.defaultFormatter": "ms-python.autopep8"
-    },
-    "python.formatting.provider": "none"
-}

--- a/app/configuration/Configuration.py
+++ b/app/configuration/Configuration.py
@@ -23,7 +23,8 @@ TYDOM_MAC = 'TYDOM_MAC'
 TYDOM_PASSWORD = 'TYDOM_PASSWORD'
 DELTADORE_LOGIN = 'DELTADORE_LOGIN'
 DELTADORE_PASSWORD = 'DELTADORE_PASSWORD'
-PRESETS_MANUAL='PRESETS_MANUAL'
+THERMOSTAT_CUSTOM_PRESETS = 'THERMOSTAT_CUSTOM_PRESETS'
+
 
 @dataclass
 class Configuration:
@@ -39,7 +40,7 @@ class Configuration:
     tydom_ip = str
     tydom_mac = str
     tydom_password = str
-    presets_manual = list
+    thermostat_custom_presets = list
 
     def __init__(self):
         self.log_level = os.getenv(LOG_LEVEL, 'INFO').upper()
@@ -56,7 +57,7 @@ class Configuration:
         self.tydom_password = os.getenv(TYDOM_PASSWORD, None)
         self.deltadore_login = os.getenv(DELTADORE_LOGIN, None)
         self.deltadore_password = os.getenv(DELTADORE_PASSWORD, None)
-        self.presets_manual = os.getenv(PRESETS_MANUAL, None)
+        self.thermostat_custom_presets = os.getenv(THERMOSTAT_CUSTOM_PRESETS, None)
 
     @staticmethod
     def load():
@@ -126,19 +127,25 @@ class Configuration:
 
     def override_configuration_with_deltadore(self):
         if self.deltadore_login is not None and self.deltadore_login != '' and self.deltadore_password is not None and self.deltadore_password != '':
-            tydom_password = TydomClient.getTydomCredentials(self.deltadore_login, self.deltadore_password, self.tydom_mac)
+            tydom_password = TydomClient.getTydomCredentials(
+                self.deltadore_login, self.deltadore_password, self.tydom_mac)
             self.tydom_password = tydom_password
 
     def validate(self):
         configuration_to_print = copy.copy(self)
 
         # Mask sensitive values before logging
-        configuration_to_print.tydom_password = Configuration.mask_value(configuration_to_print.tydom_password)
-        configuration_to_print.mqtt_password = Configuration.mask_value(configuration_to_print.mqtt_password)
-        configuration_to_print.deltadore_password = Configuration.mask_value(configuration_to_print.deltadore_password)
-        configuration_to_print.tydom_alarm_pin = Configuration.mask_value(configuration_to_print.tydom_alarm_pin)
+        configuration_to_print.tydom_password = Configuration.mask_value(
+            configuration_to_print.tydom_password)
+        configuration_to_print.mqtt_password = Configuration.mask_value(
+            configuration_to_print.mqtt_password)
+        configuration_to_print.deltadore_password = Configuration.mask_value(
+            configuration_to_print.deltadore_password)
+        configuration_to_print.tydom_alarm_pin = Configuration.mask_value(
+            configuration_to_print.tydom_alarm_pin)
 
-        logger.info('Validating configuration (%s', configuration_to_print.to_json())
+        logger.info('Validating configuration (%s',
+                    configuration_to_print.to_json())
 
         if self.tydom_mac is None or self.tydom_mac == '':
             logger.error('Tydom MAC address must be defined')

--- a/app/configuration/Configuration.py
+++ b/app/configuration/Configuration.py
@@ -23,6 +23,7 @@ TYDOM_MAC = 'TYDOM_MAC'
 TYDOM_PASSWORD = 'TYDOM_PASSWORD'
 DELTADORE_LOGIN = 'DELTADORE_LOGIN'
 DELTADORE_PASSWORD = 'DELTADORE_PASSWORD'
+PRESETS_MANUAL='PRESETS_MANUAL'
 
 @dataclass
 class Configuration:
@@ -38,6 +39,7 @@ class Configuration:
     tydom_ip = str
     tydom_mac = str
     tydom_password = str
+    presets_manual = list
 
     def __init__(self):
         self.log_level = os.getenv(LOG_LEVEL, 'INFO').upper()
@@ -54,6 +56,7 @@ class Configuration:
         self.tydom_password = os.getenv(TYDOM_PASSWORD, None)
         self.deltadore_login = os.getenv(DELTADORE_LOGIN, None)
         self.deltadore_password = os.getenv(DELTADORE_PASSWORD, None)
+        self.presets_manual = os.getenv(PRESETS_MANUAL, None)
 
     @staticmethod
     def load():

--- a/app/main.py
+++ b/app/main.py
@@ -74,7 +74,8 @@ tydom_client = TydomClient(
     mac=configuration.tydom_mac,
     host=configuration.tydom_ip,
     password=configuration.tydom_password,
-    alarm_pin=configuration.tydom_alarm_pin)
+    alarm_pin=configuration.tydom_alarm_pin,
+    presets_manual=configuration.presets_manual)
 
 # Create mqtt client
 mqtt_client = MqttClient(

--- a/app/main.py
+++ b/app/main.py
@@ -75,7 +75,7 @@ tydom_client = TydomClient(
     host=configuration.tydom_ip,
     password=configuration.tydom_password,
     alarm_pin=configuration.tydom_alarm_pin,
-    presets_manual=configuration.presets_manual)
+    thermostat_custom_presets=configuration.thermostat_custom_presets)
 
 # Create mqtt client
 mqtt_client = MqttClient(

--- a/app/sensors/Boiler.py
+++ b/app/sensors/Boiler.py
@@ -15,8 +15,8 @@ preset_mode_state_topic = "climate/tydom/{id}/thermicLevel"
 preset_mode_command_topic = "climate/tydom/{id}/set_thermicLevel"
 out_temperature_state_topic = "sensor/tydom/{id}/temperature"
 
-#temperature = current_temperature_topic
-#setpoint= temperature_command_topic
+# temperature = current_temperature_topic
+# setpoint= temperature_command_topic
 # temperature_unit=C
 # "modes": ["STOP", "ANTI-FROST","ECO", "COMFORT"],
 #####################################
@@ -27,8 +27,8 @@ out_temperature_state_topic = "sensor/tydom/{id}/temperature"
 # thermicLevel STOP ECO ...
 # auhorisation HEATING
 # hvacMode NORMAL None (si off)
-#timeDelay : 0
-#tempoOn : False
+# timeDelay : 0
+# tempoOn : False
 # antifrost True False
 # openingdetected False
 # presenceDetected False
@@ -96,7 +96,7 @@ class Boiler:
                 self.config['preset_modes'] = [
                     "STOP", "ANTI_FROST", "ECO", "COMFORT", "AUTO"]
             else:
-                self.config['preset_modes'] = [ k for k in await self.tydom_client.get_manual_presets() ]
+                self.config['preset_modes'] = [k for k in await self.tydom_client.get_manual_presets()]
             self.config['preset_mode_state_topic'] = preset_mode_state_topic.format(
                 id=self.id)
             self.config['preset_mode_command_topic'] = preset_mode_command_topic.format(
@@ -125,8 +125,9 @@ class Boiler:
                     qos=0, retain=True)
                 if await self.tydom_client.get_manual_presets() is not None:
                     presets = await self.tydom_client.get_manual_presets()
-                    if len([ i for i in presets if float(presets[i]) == float(self.attributes['setpoint']) ]) == 1:
-                        set_preset = [ i for i in presets if float(presets[i]) == float(self.attributes['setpoint']) ][0]
+                    if len([i for i in presets if float(presets[i]) == float(self.attributes['setpoint'])]) == 1:
+                        set_preset = [i for i in presets if float(
+                            presets[i]) == float(self.attributes['setpoint'])][0]
                     elif await self.tydom_client.get_current_preset(self.device_id) == "none":
                         set_preset = await self.tydom_client.get_current_preset(self.device_id)
                     elif (float(self.attributes['setpoint']) == float(presets[await self.tydom_client.get_current_preset(self.device_id)])):
@@ -148,7 +149,7 @@ class Boiler:
                         self.attributes['thermicLevel'],
                         qos=0, retain=True)
                 else:
-                     self.mqtt.mqtt_client.publish(
+                    self.mqtt.mqtt_client.publish(
                         self.config['preset_mode_state_topic'],
                         await self.tydom_client.get_current_preset(self.device_id),
                         qos=0, retain=True)
@@ -176,11 +177,12 @@ class Boiler:
     @staticmethod
     async def put_thermic_level(tydom_client, device_id, boiler_id, set_thermic_level):
         if not (set_thermic_level == ''):
-            logger.info("Set thermic level (device=%s, level=%s)", device_id, set_thermic_level)
+            logger.info("Set thermic level (device=%s, level=%s)",
+                        device_id, set_thermic_level)
             await tydom_client.put_devices_data(device_id, boiler_id, 'thermicLevel', set_thermic_level)
             if await tydom_client.get_manual_presets() is not None:
-                await tydom_client.set_current_preset(device_id, set_thermic_level )
+                await tydom_client.set_current_preset(device_id, set_thermic_level)
                 presets = await tydom_client.get_manual_presets()
                 if await tydom_client.get_current_preset(device_id) != 'none':
-                    logger.info("%s", presets[ await tydom_client.get_current_preset(device_id) ])
+                    logger.info("%s", presets[await tydom_client.get_current_preset(device_id)])
                     await tydom_client.put_devices_data(device_id, boiler_id, 'setpoint', presets[await tydom_client.get_current_preset(device_id)])

--- a/app/sensors/Boiler.py
+++ b/app/sensors/Boiler.py
@@ -124,20 +124,21 @@ class Boiler:
                     '19' if self.attributes['setpoint'] == 'None' else self.attributes['setpoint'],
                     qos=0, retain=True)
                 if await self.tydom_client.get_thermostat_custom_presets() is not None:
-                    presets = await self.tydom_client.get_thermostat_custom_presets()
-                    if len([i for i in presets if float(presets[i]) == float(self.attributes['setpoint'])]) == 1:
-                        set_preset = [i for i in presets if float(
-                            presets[i]) == float(self.attributes['setpoint'])][0]
-                    elif await self.tydom_client.get_thermostat_custom_current_preset(self.device_id) == "none":
-                        set_preset = await self.tydom_client.get_thermostat_custom_current_preset(self.device_id)
-                    elif (float(self.attributes['setpoint']) == float(presets[await self.tydom_client.get_thermostat_custom_current_preset(self.device_id)])):
-                        set_preset = await self.tydom_client.get_thermostat_custom_current_preset(self.device_id)
-                    else:
-                        set_preset = 'none'
-                    self.mqtt.mqtt_client.publish(
-                        self.config['preset_mode_state_topic'],
-                        set_preset,
-                        qos=0, retain=True)
+                    if self.attributes['setpoint'] is not None :
+                        presets = await self.tydom_client.get_thermostat_custom_presets()
+                        if len([i for i in presets if float(presets[i]) == float(self.attributes['setpoint'])]) == 1:
+                            set_preset = [i for i in presets if float(
+                                presets[i]) == float(self.attributes['setpoint'])][0]
+                        elif await self.tydom_client.get_thermostat_custom_current_preset(self.device_id) == "none":
+                            set_preset = await self.tydom_client.get_thermostat_custom_current_preset(self.device_id)
+                        elif (float(self.attributes['setpoint']) == float(presets[await self.tydom_client.get_thermostat_custom_current_preset(self.device_id)])):
+                            set_preset = await self.tydom_client.get_thermostat_custom_current_preset(self.device_id)
+                        else:
+                            set_preset = 'none'
+                        self.mqtt.mqtt_client.publish(
+                            self.config['preset_mode_state_topic'],
+                            set_preset,
+                            qos=0, retain=True)
             if 'thermicLevel' in self.attributes:
                 self.mqtt.mqtt_client.publish(
                     self.config['mode_state_topic'],

--- a/app/sensors/Boiler.py
+++ b/app/sensors/Boiler.py
@@ -92,11 +92,11 @@ class Boiler:
                 id=self.id)
             self.config['mode_command_topic'] = mode_command_topic.format(
                 id=self.id)
-            if await self.tydom_client.get_manual_presets() is None:
+            if await self.tydom_client.get_thermostat_custom_presets() is None:
                 self.config['preset_modes'] = [
                     "STOP", "ANTI_FROST", "ECO", "COMFORT", "AUTO"]
             else:
-                self.config['preset_modes'] = [k for k in await self.tydom_client.get_manual_presets()]
+                self.config['preset_modes'] = [k for k in await self.tydom_client.get_thermostat_custom_presets()]
             self.config['preset_mode_state_topic'] = preset_mode_state_topic.format(
                 id=self.id)
             self.config['preset_mode_command_topic'] = preset_mode_command_topic.format(
@@ -123,15 +123,15 @@ class Boiler:
                     self.config['temperature_state_topic'],
                     '19' if self.attributes['setpoint'] == 'None' else self.attributes['setpoint'],
                     qos=0, retain=True)
-                if await self.tydom_client.get_manual_presets() is not None:
-                    presets = await self.tydom_client.get_manual_presets()
+                if await self.tydom_client.get_thermostat_custom_presets() is not None:
+                    presets = await self.tydom_client.get_thermostat_custom_presets()
                     if len([i for i in presets if float(presets[i]) == float(self.attributes['setpoint'])]) == 1:
                         set_preset = [i for i in presets if float(
                             presets[i]) == float(self.attributes['setpoint'])][0]
-                    elif await self.tydom_client.get_current_preset(self.device_id) == "none":
-                        set_preset = await self.tydom_client.get_current_preset(self.device_id)
-                    elif (float(self.attributes['setpoint']) == float(presets[await self.tydom_client.get_current_preset(self.device_id)])):
-                        set_preset = await self.tydom_client.get_current_preset(self.device_id)
+                    elif await self.tydom_client.get_thermostat_custom_current_preset(self.device_id) == "none":
+                        set_preset = await self.tydom_client.get_thermostat_custom_current_preset(self.device_id)
+                    elif (float(self.attributes['setpoint']) == float(presets[await self.tydom_client.get_thermostat_custom_current_preset(self.device_id)])):
+                        set_preset = await self.tydom_client.get_thermostat_custom_current_preset(self.device_id)
                     else:
                         set_preset = 'none'
                     self.mqtt.mqtt_client.publish(
@@ -143,7 +143,7 @@ class Boiler:
                     self.config['mode_state_topic'],
                     "off" if self.attributes['thermicLevel'] == "STOP" else "heat",
                     qos=0, retain=True)
-                if await self.tydom_client.get_manual_presets() is None:
+                if await self.tydom_client.get_thermostat_custom_presets() is None:
                     self.mqtt.mqtt_client.publish(
                         self.config['preset_mode_state_topic'],
                         self.attributes['thermicLevel'],
@@ -151,7 +151,7 @@ class Boiler:
                 else:
                     self.mqtt.mqtt_client.publish(
                         self.config['preset_mode_state_topic'],
-                        await self.tydom_client.get_current_preset(self.device_id),
+                        await self.tydom_client.get_thermostat_custom_current_preset(self.device_id),
                         qos=0, retain=True)
             if 'outTemperature' in self.attributes:
                 self.mqtt.mqtt_client.publish(
@@ -180,9 +180,9 @@ class Boiler:
             logger.info("Set thermic level (device=%s, level=%s)",
                         device_id, set_thermic_level)
             await tydom_client.put_devices_data(device_id, boiler_id, 'thermicLevel', set_thermic_level)
-            if await tydom_client.get_manual_presets() is not None:
-                await tydom_client.set_current_preset(device_id, set_thermic_level)
-                presets = await tydom_client.get_manual_presets()
-                if await tydom_client.get_current_preset(device_id) != 'none':
-                    logger.info("%s", presets[await tydom_client.get_current_preset(device_id)])
-                    await tydom_client.put_devices_data(device_id, boiler_id, 'setpoint', presets[await tydom_client.get_current_preset(device_id)])
+            if await tydom_client.get_thermostat_custom_presets() is not None:
+                await tydom_client.set_thermostat_custom_current_preset(device_id, set_thermic_level)
+                presets = await tydom_client.get_thermostat_custom_presets()
+                if await tydom_client.get_thermostat_custom_current_preset(device_id) != 'none':
+                    logger.info("%s", presets[await tydom_client.get_thermostat_custom_current_preset(device_id)])
+                    await tydom_client.put_devices_data(device_id, boiler_id, 'setpoint', presets[await tydom_client.get_thermostat_custom_current_preset(device_id)])

--- a/app/sensors/Boiler.py
+++ b/app/sensors/Boiler.py
@@ -92,8 +92,11 @@ class Boiler:
                 id=self.id)
             self.config['mode_command_topic'] = mode_command_topic.format(
                 id=self.id)
-            self.config['preset_modes'] = [
-                "STOP", "ANTI_FROST", "ECO", "COMFORT", "AUTO"]
+            if await self.tydom_client.get_manual_presets() is None:
+                self.config['preset_modes'] = [
+                    "STOP", "ANTI_FROST", "ECO", "COMFORT", "AUTO"]
+            else:
+                self.config['preset_modes'] = [ k for k in await self.tydom_client.get_manual_presets() ]
             self.config['preset_mode_state_topic'] = preset_mode_state_topic.format(
                 id=self.id)
             self.config['preset_mode_command_topic'] = preset_mode_command_topic.format(
@@ -118,17 +121,37 @@ class Boiler:
             if 'setpoint' in self.attributes:
                 self.mqtt.mqtt_client.publish(
                     self.config['temperature_state_topic'],
-                    '10' if self.attributes['setpoint'] == 'None' else self.attributes['setpoint'],
+                    '19' if self.attributes['setpoint'] == 'None' else self.attributes['setpoint'],
                     qos=0, retain=True)
+                if await self.tydom_client.get_manual_presets() is not None:
+                    presets = await self.tydom_client.get_manual_presets()
+                    if len([ i for i in presets if float(presets[i]) == float(self.attributes['setpoint']) ]) == 1:
+                        set_preset = [ i for i in presets if float(presets[i]) == float(self.attributes['setpoint']) ][0]
+                    elif await self.tydom_client.get_current_preset(self.device_id) == "none":
+                        set_preset = await self.tydom_client.get_current_preset(self.device_id)
+                    elif (float(self.attributes['setpoint']) == float(presets[await self.tydom_client.get_current_preset(self.device_id)])):
+                        set_preset = await self.tydom_client.get_current_preset(self.device_id)
+                    else:
+                        set_preset = 'none'
+                    self.mqtt.mqtt_client.publish(
+                        self.config['preset_mode_state_topic'],
+                        set_preset,
+                        qos=0, retain=True)
             if 'thermicLevel' in self.attributes:
                 self.mqtt.mqtt_client.publish(
                     self.config['mode_state_topic'],
                     "off" if self.attributes['thermicLevel'] == "STOP" else "heat",
                     qos=0, retain=True)
-                self.mqtt.mqtt_client.publish(
-                    self.config['preset_mode_state_topic'],
-                    self.attributes['thermicLevel'],
-                    qos=0, retain=True)
+                if await self.tydom_client.get_manual_presets() is None:
+                    self.mqtt.mqtt_client.publish(
+                        self.config['preset_mode_state_topic'],
+                        self.attributes['thermicLevel'],
+                        qos=0, retain=True)
+                else:
+                     self.mqtt.mqtt_client.publish(
+                        self.config['preset_mode_state_topic'],
+                        await self.tydom_client.get_current_preset(self.device_id),
+                        qos=0, retain=True)
             if 'outTemperature' in self.attributes:
                 self.mqtt.mqtt_client.publish(
                     self.config['state_topic'],
@@ -148,10 +171,16 @@ class Boiler:
             await tydom_client.put_devices_data(device_id, boiler_id, 'thermicLevel', 'STOP')
         else:
             await tydom_client.put_devices_data(device_id, boiler_id, 'thermicLevel', 'COMFORT')
-            await tydom_client.put_devices_data(device_id, boiler_id, 'setpoint', '10')
+            await tydom_client.put_devices_data(device_id, boiler_id, 'setpoint', '19')
 
     @staticmethod
     async def put_thermic_level(tydom_client, device_id, boiler_id, set_thermic_level):
         if not (set_thermic_level == ''):
             logger.info("Set thermic level (device=%s, level=%s)", device_id, set_thermic_level)
             await tydom_client.put_devices_data(device_id, boiler_id, 'thermicLevel', set_thermic_level)
+            if await tydom_client.get_manual_presets() is not None:
+                await tydom_client.set_current_preset(device_id, set_thermic_level )
+                presets = await tydom_client.get_manual_presets()
+                if await tydom_client.get_current_preset(device_id) != 'none':
+                    logger.info("%s", presets[ await tydom_client.get_current_preset(device_id) ])
+                    await tydom_client.put_devices_data(device_id, boiler_id, 'setpoint', presets[await tydom_client.get_current_preset(device_id)])

--- a/app/tydom/TydomClient.py
+++ b/app/tydom/TydomClient.py
@@ -21,7 +21,8 @@ class TydomClient:
             mac,
             password,
             alarm_pin=None,
-            host=MEDIATION_URL):
+            host=MEDIATION_URL,
+            presets_manual=None):
         logger.debug("Initializing TydomClient Class")
 
         self.password = password
@@ -40,6 +41,9 @@ class TydomClient:
         # Some devices (like Tywatt) need polling
         self.poll_device_urls = []
         self.current_poll_index = 0
+        if presets_manual is not None:
+            self.presets_manual = json.loads(presets_manual)
+            self.current_preset = {}
 
         # Set Host, ssl context and prefix for remote or local connection
         if self.host == MEDIATION_URL:
@@ -100,7 +104,7 @@ class TydomClient:
                 and "gateway" in json_response["sites"][0]
             ):
                 password = json_response["sites"][0]["gateway"]["password"]
-
+            logger.debug("Your Tydom password : %s", json_response["sites"][0]["gateway"]["password"]) 
             return password
 
         except Exception as exception:
@@ -445,3 +449,18 @@ class TydomClient:
         await self.get_info()
         await self.post_refresh()
         await self.get_data()
+
+    async def get_manual_presets(self):
+        logger.debug("get presets")
+        return self.presets_manual
+    
+    async def get_current_preset(self, boiler_id):
+        logger.debug("get preset for %s", boiler_id)
+        print(self.current_preset)
+        if str(boiler_id) not in self.current_preset:
+            await self.set_current_preset(str(boiler_id), "none" )
+        return self.current_preset[str(boiler_id)]
+    
+    async def set_current_preset(self, boiler_id, preset):
+        logger.debug("set preset %s for %s", preset, boiler_id)
+        self.current_preset[str(boiler_id)] = str(preset)

--- a/app/tydom/TydomClient.py
+++ b/app/tydom/TydomClient.py
@@ -22,7 +22,7 @@ class TydomClient:
             password,
             alarm_pin=None,
             host=MEDIATION_URL,
-            presets_manual=None):
+            thermostat_custom_presets=None):
         logger.debug("Initializing TydomClient Class")
 
         self.password = password
@@ -41,8 +41,8 @@ class TydomClient:
         # Some devices (like Tywatt) need polling
         self.poll_device_urls = []
         self.current_poll_index = 0
-        if presets_manual is not None:
-            self.presets_manual = json.loads(presets_manual)
+        if thermostat_custom_presets is not None:
+            self.thermostat_custom_presets = json.loads(thermostat_custom_presets)
             self.current_preset = {}
 
         # Set Host, ssl context and prefix for remote or local connection
@@ -450,17 +450,17 @@ class TydomClient:
         await self.post_refresh()
         await self.get_data()
 
-    async def get_manual_presets(self):
+    async def get_thermostat_custom_presets(self):
         logger.debug("get presets")
-        return self.presets_manual
+        return self.thermostat_custom_presets
     
-    async def get_current_preset(self, boiler_id):
+    async def get_thermostat_custom_current_preset(self, boiler_id):
         logger.debug("get preset for %s", boiler_id)
         print(self.current_preset)
         if str(boiler_id) not in self.current_preset:
-            await self.set_current_preset(str(boiler_id), "none" )
+            await self.set_thermostat_custom_current_preset(str(boiler_id), "none" )
         return self.current_preset[str(boiler_id)]
     
-    async def set_current_preset(self, boiler_id, preset):
+    async def set_thermostat_custom_current_preset(self, boiler_id, preset):
         logger.debug("set preset %s for %s", preset, boiler_id)
         self.current_preset[str(boiler_id)] = str(preset)

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -21,6 +21,7 @@ Please note that only one of DELTADORE_LOGIN + DELTADORE_PASSWORD or TYDOM_PASSW
 | MQTT_PASSWORD          | :white_circle: | Mqtt broker password if authentication is enabled | `None`                     |
 | MQTT_SSL               | :white_circle: | Mqtt broker ssl enabled                           | `false`                    |
 | LOG_LEVEL              | :white_circle: | Log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`)   | `ERROR`                    |
+| THERMOSTAT_CUSTOM_PRESETS | :white_circle: | Set custom Presets for THERMOSTAT like [4890](https://www.deltadore.fr/domotique/gestion-chauffage/micromodule-recepteur/recepteur-rf4890-ref-6050615) <br/> format : { 'preset': 'temp'} (exemple { 'ECO' : '17' })   |                     |
 
 ## Complete example
 
@@ -47,3 +48,26 @@ docker run -d --name tydom2mqtt \
   fmartinou/tydom2mqtt
 ```
 <!-- tabs:end -->
+
+## THERMOSTAT_CUSTOM_PRESETS parameter
+
+### Why this parameter ?
+
+For systems like underfloor heating system, delta dore sells to other mark like Thermor some equipment like  [4890](https://www.deltadore.fr/domotique/gestion-chauffage/micromodule-recepteur/recepteur-rf4890-ref-6050615). 
+The problem is these sondes are controlled by an offline Thermostat. But each 4890 are independant and use X3D to set temperature, the offline thermostat just connect to it and ask them to change the target temperature, the sondes itself is an independant thermostat with current temperature (depends on system, internal temperature or offline thermostat temperature). The 4890 is compatible with Tydom and can be control by offline thermostat and Tydom.
+But each of 4890 are not a full themostat and doesn't have presets, each controller must set their own presets if needed.
+
+### How to use
+
+Set environment variables : THERMOSTAT_CUSTOM_PRESETS with a map of compatible presets ("STOP", "ANTI_FROST", "ECO", "COMFORT", "AUTO")
+
+exemple :
+
+```bash
+docker run -d --name tydom2mqtt \
+  -e TYDOM_MAC="001A25XXXXXX" \
+  -e TYDOM_PASSWORD="azerty123456789" \
+  -e TYDOM_IP="192.168.1.33" \ 
+  -e THERMOSTAT_CUSTOM_PRESETS='{"ECO": "17", "COMFORT": "20"}'
+  fmartinou/tydom2mqtt
+```


### PR DESCRIPTION
Hello,
I had new deltadore 4890 connected to my Tydom box and these sondes doesn't support presets, so i had a variable named PRESETS_MANUAL which managed presets inside this mqtt addon. It works fine for me in production, but the code can be better.
you can test with setting PRESETS_MANUAL={'ECO':'16', 'COMFORT': '19'} for exemple
if Presets_manual is not set, no impact. 