### PR TITLE
Fix HA 2023.8 mqtt entity naming convention warnings

### DIFF
--- a/app/sensors/Alarm.py
+++ b/app/sensors/Alarm.py
@@ -35,7 +35,7 @@ class Alarm:
             'identifiers': self.id
         }
         self.config = {
-            'name': self.name,
+            'name': None,  # set an MQTT entity's name to None to mark it as the main feature of a device
             'unique_id': self.id,
             'device': self.device,
             'command_topic': alarm_command_topic.format(id=self.id),

--- a/app/sensors/Boiler.py
+++ b/app/sensors/Boiler.py
@@ -15,8 +15,8 @@ preset_mode_state_topic = "climate/tydom/{id}/thermicLevel"
 preset_mode_command_topic = "climate/tydom/{id}/set_thermicLevel"
 out_temperature_state_topic = "sensor/tydom/{id}/temperature"
 
-#temperature = current_temperature_topic
-#setpoint= temperature_command_topic
+# temperature = current_temperature_topic
+# setpoint= temperature_command_topic
 # temperature_unit=C
 # "modes": ["STOP", "ANTI-FROST","ECO", "COMFORT"],
 #####################################
@@ -27,8 +27,8 @@ out_temperature_state_topic = "sensor/tydom/{id}/temperature"
 # thermicLevel STOP ECO ...
 # auhorisation HEATING
 # hvacMode NORMAL None (si off)
-#timeDelay : 0
-#tempoOn : False
+# timeDelay : 0
+# tempoOn : False
 # antifrost True False
 # openingdetected False
 # presenceDetected False
@@ -78,7 +78,8 @@ class Boiler:
 
         # Check if device is a heater with thermostat sensor
         else:
-            self.config['name'] = self.name
+            # set an MQTT entity's name to None to mark it as the main feature of a device
+            self.config['name'] = None
             self.device['model'] = 'Climate'
             self.config_topic = climate_config_topic.format(id=self.id)
             self.config['temperature_command_topic'] = temperature_command_topic.format(
@@ -153,5 +154,6 @@ class Boiler:
     @staticmethod
     async def put_thermic_level(tydom_client, device_id, boiler_id, set_thermic_level):
         if not (set_thermic_level == ''):
-            logger.info("Set thermic level (device=%s, level=%s)", device_id, set_thermic_level)
+            logger.info("Set thermic level (device=%s, level=%s)",
+                        device_id, set_thermic_level)
             await tydom_client.put_devices_data(device_id, boiler_id, 'thermicLevel', set_thermic_level)

--- a/app/sensors/Cover.py
+++ b/app/sensors/Cover.py
@@ -40,7 +40,7 @@ class Cover:
             'identifiers': self.id}
         self.config_topic = cover_config_topic.format(id=self.id)
         self.config = {
-            'name': self.name,
+            'name': None,  # set an MQTT entity's name to None to mark it as the main feature of a device
             'unique_id': self.id,
             'command_topic': cover_command_topic.format(
                 id=self.id),

--- a/app/sensors/Light.py
+++ b/app/sensors/Light.py
@@ -37,7 +37,7 @@ class Light:
             'identifiers': self.id}
         self.config_topic = light_config_topic.format(id=self.id)
         self.config = {
-            'name': self.name,
+            'name': None,  # set an MQTT entity's name to None to mark it as the main feature of a device
             'brightness_scale': 100,
             'unique_id': self.id,
             'optimistic': True,

--- a/app/sensors/Sensor.py
+++ b/app/sensors/Sensor.py
@@ -27,7 +27,6 @@ class Sensor:
         # extracted from json, but it will make sensor not in payload to be
         # considered offline....
         self.parent_device_id = str(tydom_attributes_payload['id'])
-        self.parent_device_name = str(tydom_attributes_payload['name'])
         self.id = elem_name + '_tydom_' + str(tydom_attributes_payload['id'])
         self.name = elem_name
         if 'device_class' in tydom_attributes_payload.keys():
@@ -106,12 +105,11 @@ class Sensor:
     async def setup(self):
         self.device = {
             'manufacturer': 'Delta Dore',
-            'name': self.parent_device_name,
             'identifiers': self.parent_device_id}
 
         self.config_sensor_topic = sensor_config_topic.format(id=self.id)
 
-        self.config = {'name': self.parent_device_name + ' ' + self.name,
+        self.config = {'name': self.name,
                        'unique_id': self.id}
         try:
             self.config['device_class'] = self.device_class

--- a/app/sensors/ShHvac.py
+++ b/app/sensors/ShHvac.py
@@ -43,7 +43,7 @@ class ShHvac:
 
         self.config_topic = thermostat_config_topic.format(id=self.id)
         self.config = {
-            'name': self.name,
+            'name': None,  # set an MQTT entity's name to None to mark it as the main feature of a device
             'unique_id': self.id,
             'device': self.device,
             'temperature_unit ': 'C',
@@ -64,7 +64,7 @@ class ShHvac:
         self.switch_config_topic = thermpstat_boost_config_topic.format(
             id=self.id)
         self.switch_config = {
-            'name': self.name + ' Boost',
+            'name': 'Boost',
             'unique_id': self.id + '_boost',
             'device': self.device,
             'payload_on': 'ON',

--- a/app/sensors/Switch.py
+++ b/app/sensors/Switch.py
@@ -39,7 +39,7 @@ class Switch:
             'identifiers': self.id}
         self.config_topic = switch_config_topic.format(id=self.id)
         self.config = {
-            'name': self.name,
+            'name': None,  # set an MQTT entity's name to None to mark it as the main feature of a device
             'unique_id': self.id,
             'command_topic': switch_command_topic.format(
                 id=self.id),


### PR DESCRIPTION
To fix the mqtt entity naming warnings of HA 2023.8 #121 , I made the following changes:

- For all supported devices, changed self.config.name to None to make the entity as the main feature of the device.
- Removed the parent device name from sensor.py.