### PR TITLE
Temperature and alarm attributes are not updated

### DIFF
--- a/app/tydom/MessageHandler.py
+++ b/app/tydom/MessageHandler.py
@@ -758,13 +758,16 @@ class MessageHandler:
                     if (sos_state):
                         logger.warning("SOS !")
 
+                    #alarm shall be update Whatever its state because sensor can be updated without any state
+                    alarm = Alarm(
+                        current_state=state,
+                        alarm_pin=self.tydom_client.alarm_pin,
+                        tydom_attributes=attr_alarm,
+                        mqtt=self.mqtt_client)
                     if not (state is None):
-                        alarm = Alarm(
-                            current_state=state,
-                            alarm_pin=self.tydom_client.alarm_pin,
-                            tydom_attributes=attr_alarm,
-                            mqtt=self.mqtt_client)
                         await alarm.update()
+                    else:
+                        await alarm.update_sensors()
 
                 except Exception as e:
                     logger.error("Error in alarm parsing !")


### PR DESCRIPTION
Sensors of the Tyxal alarm where update only at start up.
this is due to a check perform on the "state" of the alarm.
If the state was "none" (due to sensor update which doesn't interfer with alarm state), then no alarm entities where updated at all.

Now alarm state is checked in order to identify if:
- a full update is required due to alarm state change
- only a sensor update is required

this shall fix the issue 17: [https://github.com/fmartinou/tydom2mqtt/issues/17](url)