### PR TITLE
Fix websocket is not defined error

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@
 import asyncio
 import logging.config
 import socket
+import websockets
 import sys
 import signal
 


### PR DESCRIPTION
With the current version of tydom2mqtt, we can spot this error in the logs:
```
Traceback (most recent call last):
  File "/app/main.py", line 56, in listen_tydom
    except websockets.ConnectionClosed as e:
           ^^^^^^^^^^
NameError: name websockets is not defined
```