### PR TITLE
Fix SyntaxWarning

### DIFF
--- a/app/tydom/TydomClient.py
+++ b/app/tydom/TydomClient.py
@@ -309,7 +309,7 @@ class TydomClient:
             logger.warning("Tydom alarm pin is not set!")
             pass
         try:
-            if value is "ACK":
+            if value == "ACK":
                 cmd = "ackEventCmd"
                 body = ('{"pwd":"' + str(self.alarm_pin) + '"}')
             elif zone_id is None:


### PR DESCRIPTION
Thanks a lot for this add-on.

I saw the following warning in the log:

```
/app/tydom/TydomClient.py:312: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if value is "ACK":
```

This should fix it.