### PR TITLE
fix(boiler): fix hvac_action in cooling mode

### DIFF
--- a/app/sensors/Boiler.py
+++ b/app/sensors/Boiler.py
@@ -197,7 +197,7 @@ class Boiler:
                         else:
                             hvac_action = "heating"
                     elif self.current_authorization == 'COOLING':
-                        if self.current_temp > self.current_setpoint:
+                        if self.current_temp < self.current_setpoint:
                             hvac_action = "idle"
                         else:
                             hvac_action = "cooling"


### PR DESCRIPTION
Tried version 3.5.1 and "Cooling" is now displayed, but with the "Heating" logic 🙂 
![image](https://github.com/fmartinou/tydom2mqtt/assets/12021228/e92da1f3-8f95-4f5a-b58c-496f7fe2deb7)

Thankfully this is a simple fix