### PR TITLE
fix unit and calculation for energyInstant

### DIFF
--- a/app/tydom/MessageHandler.py
+++ b/app/tydom/MessageHandler.py
@@ -826,9 +826,13 @@ class MessageHandler:
                                 elif elem["name"] == "energyInstant":
                                     device_class_of_id = 'current'
                                     state_class_of_id = 'measurement'
-                                    unit_of_measurement_of_id = 'VA'
+                                    unit_of_measurement_of_id = 'A'
                                     element_name = elem["parameters"]["unit"]
                                     element_index = 'measure'
+
+                                    element_value = elem["values"][element_index]
+                                    if element_value is not None and type(element_value) == int:
+                                        element_value = element_value / 100
 
                                     attr_conso = {
                                         'device_id': device_id,
@@ -839,7 +843,7 @@ class MessageHandler:
                                         'device_class': device_class_of_id,
                                         'state_class': state_class_of_id,
                                         'unit_of_measurement': unit_of_measurement_of_id,
-                                        element_name: elem["values"][element_index]}
+                                        element_name: element_value}
 
                                     new_conso = Sensor(
                                         elem_name=element_name,


### PR DESCRIPTION
In Tywatt, energyInstant is measured in amperes.
But displayed in cents, hence the need to divide by 100.