### PR TITLE
Fix broken websockets since v14.0

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,3 +1,3 @@
-websockets>=9.1
+websockets>=14.1
 requests>=2.26
 gmqtt>=0.6

--- a/app/tydom/TydomClient.py
+++ b/app/tydom/TydomClient.py
@@ -6,7 +6,7 @@ import os
 import ssl
 import sys
 
-import websockets
+from websockets.asyncio.client import connect
 import requests
 from requests.auth import HTTPDigestAuth
 from urllib3 import encode_multipart_formdata
@@ -193,9 +193,9 @@ class TydomClient:
             websockets.client.connect returns a WebSocketClientProtocol, which is used to send and receive messages
         """
         try:
-            self.connection = await websockets.connect(
+            self.connection = await connect(
                 f"wss://{self.host}:443/mediation/client?mac={self.mac}&appli=1",
-                extra_headers=websocket_headers,
+                additional_headers=websocket_headers,
                 ssl=websocket_ssl_context,
                 ping_timeout=None,
             )


### PR DESCRIPTION
In websockets v14.0, the default connect implementation was switched to the new implementation which includes breaking changes.

See: https://websockets.readthedocs.io/en/14.1/project/changelog.html#backwards-incompatible-changes

In the current usage, this mostly means renaming the `extra_headers` arguments of `connect` for `additional_headers`.

As the current websockets version selector permits usage of version 14 (>=9.1), this means any new build of tydom2mqtt will generate a broken package.

The goal of this PR is to fix new installations