### PR TITLE
feat(alarm): support on-demand alarm PIN via MQTT JSON payload (Home Assistant code entry)

### DIFF
--- a/app/mqtt/MqttClient.py
+++ b/app/mqtt/MqttClient.py
@@ -239,13 +239,22 @@ class MqttClient:
             get_id = (topic.split("/"))[2]
             device_id = (get_id.split("_"))[0]
             endpoint_id = (get_id.split("_"))[1]
+            action = payload
+            code = None
+            try: # try to decode the JSON payload, it it fails then the action will be the raw payload (like)
+                data = json.loads(payload)
+                action = data.get("action", action)
+                code = data.get("code")
+            except json.JSONDecodeError:
+                pass
             await Alarm.put_alarm_state(
                 tydom_client=self.tydom,
                 device_id=device_id,
                 alarm_id=endpoint_id,
-                asked_state=value,
+                asked_state=action,
                 home_zone=self.home_zone,
                 night_zone=self.night_zone,
+                pin=code,
             )
 
         elif "set_setpoint" in str(topic):

--- a/app/sensors/Alarm.py
+++ b/app/sensors/Alarm.py
@@ -38,13 +38,14 @@ class Alarm:
             "device": self.device,
             "command_topic": alarm_command_topic.format(id=self.id),
             "state_topic": alarm_state_topic.format(id=self.id),
-            "code_arm_required": "false",
+            "code_arm_required": False,
         }
         self.config_alarm_topic = alarm_config_topic.format(id=self.id)
 
         if self.alarm_pin is None:
-            self.config["code"] = self.alarm_pin
-            self.config["code_arm_required"] = "true"
+            self.config["code"] = "REMOTE_CODE"
+            self.config["command_template"] = '{ "action": "{{ action }}", "code": "{{ code }}" }'
+            self.config["code_arm_required"] = True
 
         self.config["json_attributes_topic"] = alarm_attributes_topic.format(id=self.id)
 
@@ -95,7 +96,7 @@ class Alarm:
 
     @staticmethod
     async def put_alarm_state(
-        tydom_client, device_id, alarm_id, home_zone, night_zone, asked_state=None
+        tydom_client, device_id, alarm_id, home_zone, night_zone, asked_state=None, pin=None
     ):
         value = None
         zone_id = None
@@ -124,5 +125,5 @@ class Alarm:
             zone_id = None
 
         await tydom_client.put_alarm_cdata(
-            device_id=device_id, alarm_id=alarm_id, value=value, zone_id=zone_id
+            device_id=device_id, alarm_id=alarm_id, value=value, zone_id=zone_id, pin=pin
         )

--- a/app/tydom/MessageHandler.py
+++ b/app/tydom/MessageHandler.py
@@ -1118,21 +1118,77 @@ class MessageHandler:
 
     # PUT response DIRTY parsing
     def parse_put_response(self, bytes_str, start=6):
-        # TODO : Find a cooler way to parse nicely the PUT HTTP response
-        resp = bytes_str[len(self.cmd_prefix) :].decode("utf-8")
-        fields = resp.split("\r\n")
-        fields = fields[start:]  # ignore the PUT / HTTP/1.1
-        end_parsing = False
-        i = 0
-        output = str()
-        while not end_parsing:
-            field = fields[i]
-            if len(field) == 0 or field == "0":
-                end_parsing = True
-            else:
-                output += field
-                i = i + 2
-        parsed = json.loads(output)
+        """Parse incoming pseudo HTTP PUT push with optional chunked transfer.
+
+        Previous implementation skipped lines (size/data pairs) and failed when:
+          * JSON spanned multiple CRLF-delimited lines inside a single chunk
+          * Start offset differed (leading to truncated or prefixed body like '46...')
+        This version extracts headers/body, then properly de-chunks (hex sizes) and
+        assembles the JSON payload before decoding.
+        The 'start' parameter is kept for backward compatibility (ignored now).
+        """
+        raw_str = bytes_str[len(self.cmd_prefix) :].decode("utf-8", errors="ignore")
+
+        # Split headers and body
+        if "\r\n\r\n" not in raw_str:
+            logger.error("Malformed PUT frame (no header/body separator)")
+            raise ValueError("Malformed PUT frame")
+        header_part, body_part = raw_str.split("\r\n\r\n", 1)
+
+        # If not chunked just try JSON directly
+        if "Transfer-Encoding: chunked" not in header_part:
+            body = body_part.strip()
+            try:
+                parsed = json.loads(body)
+                return json.dumps(parsed)
+            except json.JSONDecodeError as e:
+                logger.error("JSON decode error (non-chunked) body=%s error=%s", body, e)
+                raise
+
+        # Chunked decoding
+        idx = 0
+        length = len(body_part)
+        assembled = []
+        while idx < length:
+            # Read chunk size line
+            line_end = body_part.find("\r\n", idx)
+            if line_end == -1:
+                break
+            size_line = body_part[idx:line_end].strip()
+            idx = line_end + 2
+            if size_line == "":
+                # skip potential blank lines
+                continue
+            if size_line == "0":
+                # End of chunks
+                break
+            # Some devices could (theoretically) send extensions after ';'
+            size_str = size_line.split(";", 1)[0]
+            try:
+                chunk_size = int(size_str, 16)
+            except ValueError:
+                # Not a proper chunk size -> treat remainder as body attempt
+                logger.debug("Unexpected chunk size line '%s', abort de-chunking", size_line)
+                assembled.append(body_part[idx:])
+                break
+            chunk = body_part[idx : idx + chunk_size]
+            assembled.append(chunk)
+            idx += chunk_size
+            # Skip trailing CRLF after chunk data if present
+            if body_part[idx : idx + 2] == "\r\n":
+                idx += 2
+
+        body = "".join(assembled).strip()
+        try:
+            parsed = json.loads(body)
+        except json.JSONDecodeError as e:
+            logger.error(
+                "JSON decode error after de-chunking body=%s error=%s (raw first 120 chars=%s)",
+                body,
+                e,
+                raw_str[:120],
+            )
+            raise
         return json.dumps(parsed)
 
     # FUNCTIONS

--- a/app/tydom/TydomClient.py
+++ b/app/tydom/TydomClient.py
@@ -301,7 +301,7 @@ class TydomClient:
         await self.connection.send(a_bytes)
         return 0
 
-    async def put_alarm_cdata(self, device_id, alarm_id=None, value=None, zone_id=None):
+    async def put_alarm_cdata(self, device_id, alarm_id=None, value=None, zone_id=None, pin=None):
         # Credits to @mgcrea on github !
         # AWAY # "PUT /devices/{}/endpoints/{}/cdata?name=alarmCmd HTTP/1.1\r\ncontent-length: 29\r\ncontent-type: application/json; charset=utf-8\r\ntransac-id: request_124\r\n\r\n\r\n{"value":"ON","pwd":{}}\r\n\r\n"
         # HOME "PUT /devices/{}/endpoints/{}/cdata?name=zoneCmd HTTP/1.1\r\ncontent-length: 41\r\ncontent-type: application/json; charset=utf-8\r\ntransac-id: request_46\r\n\r\n\r\n{"value":"ON","pwd":"{}","zones":[1]}\r\n\r\n"
@@ -318,18 +318,18 @@ class TydomClient:
         # value
         # pwd
         # zones
-
-        if self.alarm_pin is None:
+        pin_to_use = pin if pin is not None else self.alarm_pin
+        if pin_to_use is None:
             logger.warning("Tydom alarm pin is not set!")
             pass
         try:
             if value == "ACK":
                 cmd = "ackEventCmd"
-                body = '{"pwd":"' + str(self.alarm_pin) + '"}'
+                body = '{"pwd":"' + str(pin_to_use) + '"}'
             elif zone_id is None:
                 cmd = "alarmCmd"
                 body = (
-                    '{"value":"' + str(value) + '","pwd":"' + str(self.alarm_pin) + '"}'
+                    '{"value":"' + str(value) + '","pwd":"' + str(pin_to_use) + '"}'
                 )
             else:
                 cmd = "zoneCmd"


### PR DESCRIPTION
Adds support for sending alarm actions with a dynamic PIN from Home Assistant (or any client) via a JSON payload, removing the need to store the PIN in the app config. Falls back to configured `alarm_pin` if present.

Why
Previously the alarm PIN had to live in the application configuration, exposing it in plain text and preventing Home Assistant from prompting users interactively. This change lets the UI request the code at the moment of arming/disarming, improving security (no persisted secret) and user experience (native HA keypad workflow) while keeping backward compatibility for existing setups.

 Summary
- Accepts raw legacy payloads (e.g. `ARM_AWAY`) OR JSON: `{ "action": "ARM_AWAY", "code": "1234" }`.
- When no static pin configured, discovery now advertises `code_arm_required: true` and a `command_template`, prompting HA to request a code.
- Optional `code` forwarded through `Alarm.put_alarm_state` to `TydomClient.put_alarm_cdata`.
- More robust PUT/chunked response parser in `MessageHandler`.

Migration
- To enable runtime PIN entry: delete `alarm_pin` from config and redeploy.

Backward Compatibility
- Raw string commands still function.
- Existing setups with configured pin are unaffected.
- Missing or malformed JSON falls back to legacy path.