### PR TITLE
fix(boiler): proper HVAC mode handling (heat/cool/off + flicker)

### DIFF
--- a/app/mqtt/MqttClient.py
+++ b/app/mqtt/MqttClient.py
@@ -278,6 +278,7 @@ class MqttClient:
                 device_id=device_id,
                 boiler_id=endpoint_id,
                 set_hvac_mode=str(value),
+                mqtt_client=self.mqtt_client,
             )
 
         elif "set_thermicLevel" in str(topic):

--- a/app/sensors/Boiler.py
+++ b/app/sensors/Boiler.py
@@ -327,19 +327,18 @@ class Boiler:
             )
 
     @staticmethod
-    async def put_hvac_mode(tydom_client, device_id, boiler_id, set_hvac_mode):
+    async def put_hvac_mode(tydom_client, device_id, boiler_id, set_hvac_mode, mqtt_client=None):
         logger.info("%s %s %s", boiler_id, "set_hvacMode", set_hvac_mode)
+        entity_id = f"{device_id}_{boiler_id}"
 
         if set_hvac_mode == "off":
             await tydom_client.put_devices_data(
                 device_id, boiler_id, "thermicLevel", "STOP"
             )
-            await tydom_client.put_devices_data(
-                device_id, boiler_id, "authorization", "STOP"
-            )
-            await tydom_client.put_devices_data(
-                device_id, boiler_id, "hvacMode", set_hvac_mode
-            )
+            await tydom_client.put_areas_data(device_id, {"authorization": "STOP"})
+            if mqtt_client is not None:
+                mqtt_client.publish(mode_state_topic.format(id=entity_id), "off", qos=0, retain=True)
+                mqtt_client.publish(preset_mode_state_topic.format(id=entity_id), "STOP", qos=0, retain=True)
         elif set_hvac_mode == "cool":
             await tydom_client.put_devices_data(
                 device_id, boiler_id, "thermicLevel", ""
@@ -350,16 +349,10 @@ class Boiler:
                 "setpoint",
                 str(tydom_client.thermostat_heat_mode_temp_default),
             )
-            await tydom_client.put_devices_data(
-                device_id, boiler_id, "authorization", "COOLING"
-            )
-            await tydom_client.put_devices_data(
-                device_id, boiler_id, "hvacMode", set_hvac_mode
-            )
+            await tydom_client.put_areas_data(device_id, {"authorization": "COOLING"})
+            if mqtt_client is not None:
+                mqtt_client.publish(mode_state_topic.format(id=entity_id), "cool", qos=0, retain=True)
         else:
-            await tydom_client.put_devices_data(
-                device_id, boiler_id, "hvacMode", "heat"
-            )
             await tydom_client.put_devices_data(
                 device_id, boiler_id, "thermicLevel", ""
             )
@@ -369,9 +362,9 @@ class Boiler:
                 "setpoint",
                 str(tydom_client.thermostat_cool_mode_temp_default),
             )
-            await tydom_client.put_devices_data(
-                device_id, boiler_id, "authorization", "HEATING"
-            )
+            await tydom_client.put_areas_data(device_id, {"authorization": "HEATING"})
+            if mqtt_client is not None:
+                mqtt_client.publish(mode_state_topic.format(id=entity_id), "heat", qos=0, retain=True)
 
     @staticmethod
     async def put_thermic_level(tydom_client, device_id, boiler_id, set_thermic_level):

--- a/app/sensors/Boiler.py
+++ b/app/sensors/Boiler.py
@@ -338,24 +338,26 @@ class Boiler:
         logger.info("%s %s %s", boiler_id, "set_hvacMode", set_hvac_mode)
         entity_id = f"{device_id}_{boiler_id}"
 
-        # Note: switching the zone-level heat/cool authorization from HA is NOT
-        # supported by Tydom over the public protocol used here — PUT /areas/<id>/data
-        # returns HTTP 404 (the boiler's device_id is not a valid area path), and
-        # PUT /devices/<id>/endpoints/<id>/data with "authorization" returns 200 but
-        # is silently ignored by Tydom. The real channel appears to be the
-        # "events/home/hvac" stream emitted by the master thermostat, which is not
-        # yet handled (see tydom2mqtt issue #177).
+        # Two control surfaces are involved:
         #
-        # What does work and is therefore implemented here:
-        #   - off  : per-thermostat thermicLevel = STOP      (turns this thermostat off)
-        #   - cool : per-thermostat thermicLevel = ""         (releases the STOP, thermostat
-        #            follows the area's current authorization). Setpoint is reset to the
-        #            configured default.
-        #   - heat : same as cool, with the heat-mode default setpoint.
+        #   1. Zone-level HVAC direction (heat pump direction):
+        #        PUT /home/hvac/data {"mode": "STOP"|"HEATING"|"COOLING"}
+        #      Tydom broadcasts the result via PUT /devices/data (per-thermostat
+        #      authorization update) and POST /events/home/hvac.
         #
-        # Optimistic MQTT publishes give immediate UI feedback; the next /areas/data
-        # poll re-publishes the authoritative mode (combining thermicLevel and the
-        # area authorization), correcting any short-lived mismatch.
+        #   2. Per-thermostat preset:
+        #        PUT /devices/<id>/endpoints/<id>/data thermicLevel = STOP / "" / preset
+        #      "STOP" parks the thermostat regardless of zone direction; "" releases
+        #      it to follow the zone direction.
+        #
+        # Mapping HA modes:
+        #   - off  : thermicLevel = STOP only (per-thermostat). Does NOT change zone
+        #            direction, so siblings sharing the heat pump keep running.
+        #   - cool : zone -> COOLING, thermicLevel -> "" (active), reset setpoint
+        #   - heat : zone -> HEATING, thermicLevel -> "" (active), reset setpoint
+        #
+        # Optimistic MQTT publishes give immediate UI feedback; the next push from
+        # Tydom (broadcast on the open WebSocket) confirms or corrects the state.
         if set_hvac_mode == "off":
             await tydom_client.put_devices_data(
                 device_id, boiler_id, "thermicLevel", "STOP"
@@ -364,6 +366,7 @@ class Boiler:
                 mqtt_client.publish(mode_state_topic.format(id=entity_id), "off", qos=0, retain=True)
                 mqtt_client.publish(preset_mode_state_topic.format(id=entity_id), "STOP", qos=0, retain=True)
         elif set_hvac_mode == "cool":
+            await tydom_client.put_home_hvac_mode("COOLING")
             await tydom_client.put_devices_data(
                 device_id, boiler_id, "thermicLevel", ""
             )
@@ -376,6 +379,7 @@ class Boiler:
             if mqtt_client is not None:
                 mqtt_client.publish(mode_state_topic.format(id=entity_id), "cool", qos=0, retain=True)
         else:
+            await tydom_client.put_home_hvac_mode("HEATING")
             await tydom_client.put_devices_data(
                 device_id, boiler_id, "thermicLevel", ""
             )

--- a/app/sensors/Boiler.py
+++ b/app/sensors/Boiler.py
@@ -338,11 +338,28 @@ class Boiler:
         logger.info("%s %s %s", boiler_id, "set_hvacMode", set_hvac_mode)
         entity_id = f"{device_id}_{boiler_id}"
 
+        # Note: switching the zone-level heat/cool authorization from HA is NOT
+        # supported by Tydom over the public protocol used here — PUT /areas/<id>/data
+        # returns HTTP 404 (the boiler's device_id is not a valid area path), and
+        # PUT /devices/<id>/endpoints/<id>/data with "authorization" returns 200 but
+        # is silently ignored by Tydom. The real channel appears to be the
+        # "events/home/hvac" stream emitted by the master thermostat, which is not
+        # yet handled (see tydom2mqtt issue #177).
+        #
+        # What does work and is therefore implemented here:
+        #   - off  : per-thermostat thermicLevel = STOP      (turns this thermostat off)
+        #   - cool : per-thermostat thermicLevel = ""         (releases the STOP, thermostat
+        #            follows the area's current authorization). Setpoint is reset to the
+        #            configured default.
+        #   - heat : same as cool, with the heat-mode default setpoint.
+        #
+        # Optimistic MQTT publishes give immediate UI feedback; the next /areas/data
+        # poll re-publishes the authoritative mode (combining thermicLevel and the
+        # area authorization), correcting any short-lived mismatch.
         if set_hvac_mode == "off":
             await tydom_client.put_devices_data(
                 device_id, boiler_id, "thermicLevel", "STOP"
             )
-            await tydom_client.put_areas_data(device_id, {"authorization": "STOP"})
             if mqtt_client is not None:
                 mqtt_client.publish(mode_state_topic.format(id=entity_id), "off", qos=0, retain=True)
                 mqtt_client.publish(preset_mode_state_topic.format(id=entity_id), "STOP", qos=0, retain=True)
@@ -356,7 +373,6 @@ class Boiler:
                 "setpoint",
                 str(tydom_client.thermostat_heat_mode_temp_default),
             )
-            await tydom_client.put_areas_data(device_id, {"authorization": "COOLING"})
             if mqtt_client is not None:
                 mqtt_client.publish(mode_state_topic.format(id=entity_id), "cool", qos=0, retain=True)
         else:
@@ -369,7 +385,6 @@ class Boiler:
                 "setpoint",
                 str(tydom_client.thermostat_cool_mode_temp_default),
             )
-            await tydom_client.put_areas_data(device_id, {"authorization": "HEATING"})
             if mqtt_client is not None:
                 mqtt_client.publish(mode_state_topic.format(id=entity_id), "heat", qos=0, retain=True)
 

--- a/app/sensors/Boiler.py
+++ b/app/sensors/Boiler.py
@@ -59,6 +59,7 @@ class Boiler:
         self.current_temp = None
         self.current_setpoint = None
         self.current_authorization = None
+        self.current_thermic_level = None
 
     async def setup(self):
         self.config = {}
@@ -140,6 +141,10 @@ class Boiler:
                 self.id,
                 "current_authorization",
             )
+            self.current_thermic_level = await self.tydom_client.get_in_memory(
+                self.id,
+                "current_thermic_level",
+            )
 
             if (
                 "authorization" in self.attributes
@@ -148,6 +153,12 @@ class Boiler:
                 self.current_authorization = self.attributes["authorization"]
                 await self.tydom_client.set_in_memory(
                     self.id, "current_authorization", self.current_authorization
+                )
+
+            if "thermicLevel" in self.attributes:
+                self.current_thermic_level = self.attributes["thermicLevel"]
+                await self.tydom_client.set_in_memory(
+                    self.id, "current_thermic_level", self.current_thermic_level
                 )
 
             if "temperature" in self.attributes:
@@ -264,16 +275,6 @@ class Boiler:
                     )
 
             if "thermicLevel" in self.attributes and self.attributes["thermicLevel"]:
-                self.mqtt.mqtt_client.publish(
-                    self.config["mode_state_topic"],
-                    "off"
-                    if self.attributes["thermicLevel"] == "STOP"
-                    else "cool"
-                    if self.attributes["thermicLevel"] is None
-                    else "heat",
-                    qos=0,
-                    retain=True,
-                )
                 if await self.tydom_client.get_thermostat_custom_presets() is None:
                     self.mqtt.mqtt_client.publish(
                         self.config["preset_mode_state_topic"],
@@ -297,23 +298,29 @@ class Boiler:
                     qos=0,
                     retain=True,
                 )
-            if "authorization" in self.attributes:
+            # Coherent hvac mode: combine thermicLevel (per-thermostat preset)
+            # and authorization (area heat/cool direction). Single publish to
+            # avoid the off/cool flicker when both arrive in the same update.
+            if self.current_thermic_level is not None or self.current_authorization is not None:
+                if self.current_thermic_level == "STOP":
+                    mode = "off"
+                elif self.current_authorization == "STOP":
+                    mode = "off"
+                elif self.current_authorization == "COOLING":
+                    mode = "cool"
+                elif self.current_authorization == "HEATING":
+                    mode = "heat"
+                else:
+                    mode = "heat"
                 logger.debug(
-                    "authorization : publish  %s to %s",
-                    self.config["mode_state_topic"],
-                    "off"
-                    if self.attributes["authorization"] == "STOP"
-                    else "cool"
-                    if self.attributes["authorization"] == "COOLING"
-                    else "heat",
+                    "hvacMode publish %s (thermicLevel=%s authorization=%s)",
+                    mode,
+                    self.current_thermic_level,
+                    self.current_authorization,
                 )
                 self.mqtt.mqtt_client.publish(
                     self.config["mode_state_topic"],
-                    "off"
-                    if self.attributes["authorization"] == "STOP"
-                    else "cool"
-                    if self.attributes["authorization"] == "COOLING"
-                    else "heat",
+                    mode,
                     qos=0,
                     retain=True,
                 )

--- a/app/tydom/MessageHandler.py
+++ b/app/tydom/MessageHandler.py
@@ -405,6 +405,8 @@ class MessageHandler:
                 msg_type = "msg_html"
             elif "productName" in first:
                 msg_type = "msg_info"
+            elif "mode" in first and "support" in data:
+                msg_type = "msg_area_authorization"
 
             if msg_type is None:
                 logger.warning("Unknown message type received (%s)", data)
@@ -432,6 +434,11 @@ class MessageHandler:
 
                     elif msg_type == "msg_info":
                         pass
+
+                    elif msg_type == "msg_area_authorization":
+                        parsed = json.loads(data)
+                        logger.debug("Zone authorization notification: mode=%s support=%s",
+                                     parsed.get("mode"), parsed.get("support"))
                 except Exception as e:
                     logger.error("Error on parsing tydom response (%s)", e)
                     logger.error("Incoming data (%s)", data)

--- a/app/tydom/TydomClient.py
+++ b/app/tydom/TydomClient.py
@@ -301,6 +301,28 @@ class TydomClient:
         await self.connection.send(a_bytes)
         return 0
 
+    async def put_home_hvac_mode(self, mode):
+        """Set the zone-level HVAC mode (STOP / HEATING / COOLING).
+
+        Tells the heat pump which way to run (or stop). Tydom acknowledges
+        with a 200 OK then broadcasts the resulting state to all clients via
+        PUT /devices/data (per-thermostat authorization update) and
+        POST /events/home/hvac.
+        """
+        body = '{"mode":"' + mode + '"}'
+        str_request = (
+            self.cmd_prefix
+            + "PUT /home/hvac/data HTTP/1.1\r\nContent-Length: "
+            + str(len(body))
+            + "\r\nContent-Type: application/json; charset=UTF-8\r\nTransac-Id: 0\r\n\r\n"
+            + body
+            + "\r\n\r\n"
+        )
+        a_bytes = bytes(str_request, "ascii")
+        logger.debug("Sending message to tydom (%s %s)", "PUT home hvac data", body)
+        await self.connection.send(a_bytes)
+        return 0
+
     async def put_alarm_cdata(self, device_id, alarm_id=None, value=None, zone_id=None):
         # Credits to @mgcrea on github !
         # AWAY # "PUT /devices/{}/endpoints/{}/cdata?name=alarmCmd HTTP/1.1\r\ncontent-length: 29\r\ncontent-type: application/json; charset=utf-8\r\ntransac-id: request_124\r\n\r\n\r\n{"value":"ON","pwd":{}}\r\n\r\n"


### PR DESCRIPTION
## Problem

When changing HVAC mode (heat/cool/off) via Home Assistant for Delta Dore Tydom thermostats, the mode change appeared to succeed but reverted within seconds. After protocol sniffing against a real Tydom hub, three independent bugs were identified — two in the SET path (`Boiler.put_hvac_mode()`) and one in the READ path (`Boiler.update()`). All three are now fixed.

### Bug 1 — Invalid `hvacMode` PUT on device endpoint

```python
# Before (broken)
await tydom_client.put_devices_data(device_id, boiler_id, "hvacMode", "HEATING")
```

The Tydom API returns **HTTP 400** for this call. `hvacMode` is read-only on device endpoints — it reflects the current mode but cannot be set.

### Bug 2 — Wrong endpoint for zone HVAC direction

Earlier attempts in this PR tried two paths to set the zone-level heat/cool direction; both fail silently:

```python
# Returns HTTP 200 but Tydom ignores it
await tydom_client.put_devices_data(device_id, boiler_id, "authorization", "HEATING")

# Returns HTTP 404 — the boiler's device_id is not a valid area path on this hub
await tydom_client.put_areas_data(device_id, {"authorization": "HEATING"})
```

The optimistic MQTT publish hid the failure, so the dashboard mode flipped visually while the heat pump kept running in the previous direction.

**The correct endpoint is `PUT /home/hvac/data`**, identified by capturing the broadcast Tydom emits when the official Tydom app changes the mode:

```
07:51:40  PUT /devices/data  authorization=COOLING (per thermostat)   ← from hub
07:51:40  PUT /devices/data  heatSetpoint=null, coolSetpoint=...      ← from hub
07:51:41  POST /events/home/hvac  {"mode":"COOLING","support":[...]}  ← from hub
```

After probing several candidate write endpoints, the inverse path that triggers the same broadcast is:

```
PUT /home/hvac/data
{"mode": "STOP" | "HEATING" | "COOLING"}
```

Verified live: sending `{"mode":"HEATING"}` returns 200 OK and Tydom immediately broadcasts `authorization=HEATING` on every thermostat in the zone plus the matching `events/home/hvac` notification. State propagates to HA in ~2 s.

### Bug 3 — Dual `hvacMode` publish on every keepalive (read path)

In `Boiler.update()`, two separate branches each published to `mode_state_topic`:

- One based on `thermicLevel` (`STOP` → `off`, else `heat`/`cool`)
- One based on `authorization` (`STOP` → `off`, `COOLING` → `cool`, `HEATING` → `heat`)

When a Tydom keepalive (~every 60 s) contained both fields and they disagreed — typical case: a thermostat preset is `STOP` while its zone authorization stays `COOLING` — MQTT published `off` immediately followed by `cool` within milliseconds. HA recorded both as state changes, with `cool` winning. Fixed by caching both fields and emitting a single coherent publish per update.

```
# Before (per minute)
hvacMode off       <-- thermicLevel branch
thermicLevel STOP
hvacMode cool      <-- authorization branch (overrides)

# After
thermicLevel STOP
hvacMode off       <-- single coherent publish
```

## Changes

### `app/tydom/TydomClient.py`

- New `put_home_hvac_mode(mode)` that issues `PUT /home/hvac/data {"mode": ...}` (the zone-level command)

### `app/sensors/Boiler.py`

**SET path (`put_hvac_mode`):**
- Remove `put_devices_data(..., "hvacMode", ...)` calls (always 400)
- Remove `put_devices_data(..., "authorization", ...)` calls (200-but-ignored)
- Remove `put_areas_data(..., {"authorization": ...})` calls (404)
- For **cool / heat**, call `put_home_hvac_mode("COOLING" | "HEATING")` to switch the zone direction, then set `thermicLevel=""` and the configured default setpoint on the per-thermostat endpoint
- For **off**, keep per-thermostat `thermicLevel = STOP` only (intentionally does not stop the zone — siblings sharing the heat pump are untouched)
- Add optional `mqtt_client` parameter to publish optimistic state updates immediately while the broadcast is in flight

**READ path (`update`):**
- Cache `current_thermic_level` alongside the existing `current_authorization` (loaded/persisted via `get_in_memory`/`set_in_memory`)
- Replace the two scattered `mode_state_topic` publishes with a single unified publish at the end of `update()`:
  - `thermic_level == STOP` → `off`
  - `authorization == STOP` → `off`
  - `authorization == COOLING` → `cool`
  - `authorization == HEATING` → `heat`

### `app/tydom/MessageHandler.py`

- Add detection and handling of zone authorization notification messages (`{"mode": "COOLING", "support": [...]}`) that were previously logged as `Unknown message type received`

### `app/mqtt/MqttClient.py`

- Pass `mqtt_client=self.mqtt_client` to `Boiler.put_hvac_mode()` to enable optimistic state updates

## Verification

Tested on real hardware:

- **Delta Dore Tydom Home** gateway with X3D module + Daikin Altherma heat pump
- Two thermostat endpoints (Zone Jour + Zone Nuit) sharing one HVAC zone
- Cycled `heat → cool → off` from HA Lovelace
- Confirmed `PUT /home/hvac/data` returns 200 and Tydom broadcasts `authorization=HEATING / COOLING` on both thermostats within ~2 s
- Confirmed the per-minute keepalive publishes a single coherent `hvacMode` value per thermostat (no more `off → cool` flicker)
- No more `Unknown message type received` warnings in logs for `events/home/hvac` pushes

## Backwards compatibility

- New `put_home_hvac_mode` method on `TydomClient` — additive, no existing callers
- `mqtt_client` parameter in `put_hvac_mode()` defaults to `None` — existing callers unaffected
- New `current_thermic_level` cache key in `set_in_memory` — new key, no collision
- No changes to MQTT topic structure or discovery payloads
- No new dependencies