### PR TITLE
feat: implement a healthcheck endpoint and Docker HEALTHCHECK

### DIFF
--- a/.Dockerignore
+++ b/.Dockerignore
@@ -1,3 +1,5 @@
 .idea/
 .git/
 **/__pycache__/
+# Never bake local secrets into the image
+*.env

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,51 @@
+# tydom2mqtt configuration example.
+#
+# Copy this file to ".env" (kept out of git by *.env in .gitignore) and fill in
+# your own values, then run:
+#   docker run -d --name tydom2mqtt --env-file .env -p 8080:8080 tydom2mqtt
+#
+# Notes for --env-file: no quotes around values, no variable expansion,
+# lines starting with # are comments.
+
+# --- Tydom (required) ---------------------------------------------------------
+# Tydom MAC address (starts with 001A...)
+TYDOM_MAC=001A25XXXXXX
+# Either set TYDOM_PASSWORD directly...
+TYDOM_PASSWORD=changeme
+# ...or let it be retrieved from your Delta Dore account (leave TYDOM_PASSWORD empty then):
+# DELTADORE_LOGIN=you@example.com
+# DELTADORE_PASSWORD=changeme
+
+# Tydom IPv4/FQDN. Default mediation.tydom.com = remote mode; set a local IP for local mode.
+TYDOM_IP=mediation.tydom.com
+# Polling interval in seconds (drives the health timeouts: 2x this value, 600s floor)
+TYDOM_POLLING_INTERVAL=300
+
+# --- Alarm (optional) ---------------------------------------------------------
+# TYDOM_ALARM_PIN=
+# TYDOM_ALARM_HOME_ZONE=1
+# TYDOM_ALARM_NIGHT_ZONE=2
+
+# --- Thermostat (optional) ----------------------------------------------------
+# THERMOSTAT_COOL_MODE_TEMP_DEFAULT=26
+# THERMOSTAT_HEAT_MODE_TEMP_DEFAULT=16
+# THERMOSTAT_CUSTOM_PRESETS={ 'ECO' : '17' }
+
+# --- MQTT ---------------------------------------------------------------------
+MQTT_HOST=localhost
+MQTT_PORT=1883
+# MQTT_USER=
+# MQTT_PASSWORD=
+# MQTT_SSL: leave UNSET for a plain (non-TLS) broker. Do not set it to "false":
+# the value is read as a raw string and any non-empty string breaks the gmqtt
+# connection ('str' object has no attribute 'wrap_bio').
+# MQTT_SSL=
+
+# --- Health check (optional) --------------------------------------------------
+# Enable the /health HTTP endpoint and Docker HEALTHCHECK (true/1/yes to enable)
+HEALTH_ENABLED=true
+# Port the health server listens on (must match Dockerfile EXPOSE / -p mapping)
+HEALTH_PORT=8080
+
+# --- Logging ------------------------------------------------------------------
+# LOG_LEVEL=INFO

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,12 @@ COPY /app .
 # Install dependencies
 RUN pip3 install -r requirements.txt
 
+# Expose health check port
+EXPOSE 8080
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD python /app/healthcheck.py
+
 # Main command
 CMD [ "python", "-u", "main.py" ]

--- a/app/configuration/Configuration.py
+++ b/app/configuration/Configuration.py
@@ -27,6 +27,8 @@ DELTADORE_PASSWORD = "DELTADORE_PASSWORD"
 THERMOSTAT_CUSTOM_PRESETS = "THERMOSTAT_CUSTOM_PRESETS"
 THERMOSTAT_COOL_MODE_TEMP_DEFAULT = "THERMOSTAT_COOL_MODE_TEMP_DEFAULT"
 THERMOSTAT_HEAT_MODE_TEMP_DEFAULT = "THERMOSTAT_HEAT_MODE_TEMP_DEFAULT"
+HEALTH_ENABLED = "HEALTH_ENABLED"
+HEALTH_PORT = "HEALTH_PORT"
 
 
 @dataclass
@@ -47,6 +49,8 @@ class Configuration:
     thermostat_cool_mode_temp_default = int
     thermostat_heat_mode_temp_default = int
     tydom_polling_interval = int
+    health_enabled = bool
+    health_port = int
 
     def __init__(self):
         self.log_level = os.getenv(LOG_LEVEL, "INFO").upper()
@@ -71,6 +75,9 @@ class Configuration:
         self.thermostat_heat_mode_temp_default = os.getenv(
             THERMOSTAT_HEAT_MODE_TEMP_DEFAULT, 16
         )
+        health_enabled_str = os.getenv(HEALTH_ENABLED, "true").lower()
+        self.health_enabled = health_enabled_str in ("true", "1", "yes")
+        self.health_port = int(os.getenv(HEALTH_PORT, 8080))
 
     @staticmethod
     def load():

--- a/app/health/HealthServer.py
+++ b/app/health/HealthServer.py
@@ -1,0 +1,116 @@
+import asyncio
+import json
+import logging
+from typing import Optional
+
+from .HealthState import HealthState
+
+logger = logging.getLogger(__name__)
+
+
+class HealthServer:
+    """Minimal async HTTP server for health checks."""
+
+    def __init__(self, port: int = 8080):
+        self.port = port
+        self.health_state = HealthState()
+        self._server: Optional[asyncio.AbstractServer] = None
+
+    async def handle_client(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        """Handle an incoming HTTP request."""
+        try:
+            # Read the request line
+            request_line = await asyncio.wait_for(
+                reader.readline(), timeout=5.0
+            )
+            if not request_line:
+                return
+
+            request_str = request_line.decode("utf-8", errors="ignore").strip()
+            logger.debug("Health server received: %s", request_str)
+
+            # Parse request
+            parts = request_str.split()
+            if len(parts) >= 2:
+                method, path = parts[0], parts[1]
+            else:
+                method, path = "GET", "/"
+
+            # Drain remaining headers
+            while True:
+                line = await asyncio.wait_for(reader.readline(), timeout=5.0)
+                if line == b"\r\n" or line == b"\n" or not line:
+                    break
+
+            # Handle routes
+            if method == "GET" and path == "/health":
+                await self._send_health_response(writer)
+            else:
+                await self._send_not_found(writer)
+
+        except asyncio.TimeoutError:
+            logger.debug("Health server request timeout")
+        except Exception as e:
+            logger.debug("Health server error: %s", e)
+        finally:
+            try:
+                writer.close()
+                await writer.wait_closed()
+            except Exception:
+                pass
+
+    async def _send_health_response(self, writer: asyncio.StreamWriter) -> None:
+        """Send the health check response."""
+        status_dict = self.health_state.get_status_dict()
+        body = json.dumps(status_dict, indent=2)
+
+        if status_dict["healthy"]:
+            status_line = "HTTP/1.1 200 OK"
+        else:
+            status_line = "HTTP/1.1 503 Service Unavailable"
+
+        response = (
+            f"{status_line}\r\n"
+            f"Content-Type: application/json\r\n"
+            f"Content-Length: {len(body)}\r\n"
+            f"Connection: close\r\n"
+            f"\r\n"
+            f"{body}"
+        )
+
+        writer.write(response.encode("utf-8"))
+        await writer.drain()
+
+    async def _send_not_found(self, writer: asyncio.StreamWriter) -> None:
+        """Send a 404 response."""
+        body = '{"error": "Not Found"}'
+        response = (
+            f"HTTP/1.1 404 Not Found\r\n"
+            f"Content-Type: application/json\r\n"
+            f"Content-Length: {len(body)}\r\n"
+            f"Connection: close\r\n"
+            f"\r\n"
+            f"{body}"
+        )
+        writer.write(response.encode("utf-8"))
+        await writer.drain()
+
+    async def start(self) -> None:
+        """Start the health server."""
+        try:
+            self._server = await asyncio.start_server(
+                self.handle_client, "0.0.0.0", self.port
+            )
+            logger.info("Health server started on port %d", self.port)
+        except Exception as e:
+            logger.error("Failed to start health server: %s", e)
+            raise
+
+    async def stop(self) -> None:
+        """Stop the health server."""
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            logger.info("Health server stopped")

--- a/app/health/HealthServer.py
+++ b/app/health/HealthServer.py
@@ -22,9 +22,7 @@ class HealthServer:
         """Handle an incoming HTTP request."""
         try:
             # Read the request line
-            request_line = await asyncio.wait_for(
-                reader.readline(), timeout=5.0
-            )
+            request_line = await asyncio.wait_for(reader.readline(), timeout=5.0)
             if not request_line:
                 return
 

--- a/app/health/HealthState.py
+++ b/app/health/HealthState.py
@@ -27,9 +27,22 @@ class HealthState:
         self.last_tydom_message_time: Optional[float] = None
         self.tasks_heartbeat: Dict[str, float] = {}
 
-        # Configuration
-        self.message_timeout: int = 300  # 5 minutes default
-        self.heartbeat_timeout: int = 600  # 10 minutes default (2x polling interval)
+        # Timeout configuration. These are conservative startup defaults;
+        # main.py overrides both at boot via set_timeouts_from_polling_interval()
+        # so they scale with the Tydom polling interval.
+        self.message_timeout: int = 600  # max age of last Tydom message (seconds)
+        self.heartbeat_timeout: int = 600  # max age of a task heartbeat (seconds)
+
+    def set_timeouts_from_polling_interval(self, polling_interval: int) -> None:
+        """Derive the health timeouts from the Tydom polling interval.
+
+        Both signals must tolerate at least one full polling cycle plus the
+        latency of the response, otherwise a quiet-but-working installation
+        (whose only guaranteed traffic is the periodic poll) would flap
+        unhealthy. We use 2x the interval with a 600s floor.
+        """
+        self.heartbeat_timeout = max(600, polling_interval * 2)
+        self.message_timeout = max(600, polling_interval * 2)
 
     def update_mqtt_status(self, connected: bool) -> None:
         """Update MQTT connection status."""

--- a/app/health/HealthState.py
+++ b/app/health/HealthState.py
@@ -1,0 +1,120 @@
+import logging
+import time
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class HealthState:
+    """Singleton class tracking connection states and task health."""
+
+    _instance: Optional["HealthState"] = None
+
+    def __new__(cls) -> "HealthState":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance._initialized = False
+        return cls._instance
+
+    def __init__(self):
+        if self._initialized:
+            return
+        self._initialized = True
+
+        self.start_time: float = time.time()
+        self.mqtt_connected: bool = False
+        self.tydom_connected: bool = False
+        self.last_tydom_message_time: Optional[float] = None
+        self.tasks_heartbeat: Dict[str, float] = {}
+
+        # Configuration
+        self.message_timeout: int = 300  # 5 minutes default
+        self.heartbeat_timeout: int = 600  # 10 minutes default (2x polling interval)
+
+    def update_mqtt_status(self, connected: bool) -> None:
+        """Update MQTT connection status."""
+        self.mqtt_connected = connected
+        logger.debug("Health: MQTT connected=%s", connected)
+
+    def update_tydom_status(self, connected: bool) -> None:
+        """Update Tydom WebSocket connection status."""
+        self.tydom_connected = connected
+        if connected:
+            self.last_tydom_message_time = time.time()
+        logger.debug("Health: Tydom connected=%s", connected)
+
+    def update_tydom_message_time(self) -> None:
+        """Update the timestamp of last received Tydom message."""
+        self.last_tydom_message_time = time.time()
+
+    def update_task_heartbeat(self, task_name: str) -> None:
+        """Update heartbeat timestamp for a task."""
+        self.tasks_heartbeat[task_name] = time.time()
+        logger.debug("Health: Task %s heartbeat updated", task_name)
+
+    def is_healthy(self) -> bool:
+        """Check if the application is healthy."""
+        now = time.time()
+
+        # Check MQTT connection
+        if not self.mqtt_connected:
+            logger.debug("Health: Unhealthy - MQTT not connected")
+            return False
+
+        # Check Tydom connection
+        if not self.tydom_connected:
+            logger.debug("Health: Unhealthy - Tydom not connected")
+            return False
+
+        # Check if we've received messages recently
+        if self.last_tydom_message_time is not None:
+            time_since_message = now - self.last_tydom_message_time
+            if time_since_message > self.message_timeout:
+                logger.debug(
+                    "Health: Unhealthy - No Tydom message for %d seconds",
+                    int(time_since_message),
+                )
+                return False
+
+        # Check task heartbeats
+        for task_name, last_heartbeat in self.tasks_heartbeat.items():
+            time_since_heartbeat = now - last_heartbeat
+            if time_since_heartbeat > self.heartbeat_timeout:
+                logger.debug(
+                    "Health: Unhealthy - Task %s heartbeat timeout (%d seconds)",
+                    task_name,
+                    int(time_since_heartbeat),
+                )
+                return False
+
+        return True
+
+    def get_status_dict(self) -> dict:
+        """Get a dictionary with current health status."""
+        now = time.time()
+        uptime = now - self.start_time
+
+        tasks_status = {}
+        for task_name, last_heartbeat in self.tasks_heartbeat.items():
+            tasks_status[task_name] = {
+                "last_heartbeat_seconds_ago": int(now - last_heartbeat),
+                "healthy": (now - last_heartbeat) <= self.heartbeat_timeout,
+            }
+
+        message_age = None
+        if self.last_tydom_message_time is not None:
+            message_age = int(now - self.last_tydom_message_time)
+
+        return {
+            "healthy": self.is_healthy(),
+            "uptime_seconds": int(uptime),
+            "mqtt_connected": self.mqtt_connected,
+            "tydom_connected": self.tydom_connected,
+            "last_tydom_message_seconds_ago": message_age,
+            "tasks": tasks_status,
+        }
+
+    @classmethod
+    def reset(cls) -> None:
+        """Reset the singleton instance (for testing)."""
+        cls._instance = None

--- a/app/health/__init__.py
+++ b/app/health/__init__.py
@@ -1,0 +1,4 @@
+from .HealthState import HealthState
+from .HealthServer import HealthServer
+
+__all__ = ["HealthState", "HealthServer"]

--- a/app/healthcheck.py
+++ b/app/healthcheck.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Docker healthcheck script for tydom2mqtt."""
+
 import http.client
 import os
 import sys

--- a/app/healthcheck.py
+++ b/app/healthcheck.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""Docker healthcheck script for tydom2mqtt."""
+import http.client
+import os
+import sys
+
+
+def main():
+    port = int(os.getenv("HEALTH_PORT", 8080))
+    try:
+        conn = http.client.HTTPConnection("localhost", port, timeout=5)
+        conn.request("GET", "/health")
+        response = conn.getresponse()
+        conn.close()
+        sys.exit(0 if response.status == 200 else 1)
+    except Exception:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,8 @@ from configuration.Configuration import Configuration
 from mqtt.MqttClient import MqttClient
 from tydom.TydomClient import TydomClient
 from tydom.MessageHandler import MessageHandler
+from health.HealthState import HealthState
+from health.HealthServer import HealthServer
 
 # Setup logger configuration
 logging.basicConfig(level="INFO", format="%(asctime)s - %(message)s")
@@ -36,6 +38,16 @@ if configuration.log_level != "DEBUG":
     logging.getLogger("gmqtt").setLevel(logging.WARNING)
     logging.getLogger("websockets").setLevel(logging.WARNING)
 
+# Initialize health state singleton
+health_state = HealthState()
+# Set heartbeat timeout based on polling interval (2x polling interval)
+health_state.heartbeat_timeout = int(configuration.tydom_polling_interval) * 2
+
+# Initialize health server if enabled
+health_server = None
+if configuration.health_enabled:
+    health_server = HealthServer(port=configuration.health_port)
+
 
 # Listen to tydom events.
 async def listen_tydom():
@@ -46,6 +58,8 @@ async def listen_tydom():
             while True:
                 try:
                     incoming_bytes_str = await tydom_client.connection.recv()
+                    health_state.update_task_heartbeat("listen_tydom")
+                    health_state.update_tydom_message_time()
                     message_handler = MessageHandler(
                         incoming_bytes=incoming_bytes_str,
                         tydom_client=tydom_client,
@@ -72,6 +86,7 @@ async def poll_device_tydom():
     while True:
         try:
             await asyncio.sleep(tydom_client.polling_interval)
+            health_state.update_task_heartbeat("poll_device_tydom")
             await tydom_client.post_refresh()
         except Exception as e:
             logger.warning("poll_device_tydom error : %s", e)
@@ -108,6 +123,10 @@ async def shutdown(signal, loop):
     logging.info("Cancelling running tasks")
 
     try:
+        # Stop health server
+        if health_server is not None:
+            await health_server.stop()
+
         # Close connections
         await tydom_client.disconnect()
 
@@ -122,6 +141,11 @@ async def shutdown(signal, loop):
         loop.stop()
 
 
+async def start_health_server():
+    if health_server is not None:
+        await health_server.start()
+
+
 def main():
     loop = asyncio.new_event_loop()
     signals = (signal.SIGHUP, signal.SIGTERM, signal.SIGINT)
@@ -131,6 +155,7 @@ def main():
     loop.create_task(mqtt_client.connect())
     loop.create_task(listen_tydom())
     loop.create_task(poll_device_tydom())
+    loop.create_task(start_health_server())
     loop.run_forever()
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -40,8 +40,10 @@ if configuration.log_level != "DEBUG":
 
 # Initialize health state singleton
 health_state = HealthState()
-# Set heartbeat timeout based on polling interval (2x polling interval)
-health_state.heartbeat_timeout = int(configuration.tydom_polling_interval) * 2
+# Derive the health timeouts from the polling interval (see HealthState).
+health_state.set_timeouts_from_polling_interval(
+    int(configuration.tydom_polling_interval)
+)
 
 # Initialize health server if enabled
 health_server = None
@@ -57,7 +59,17 @@ async def listen_tydom():
             await tydom_client.setup()
             while True:
                 try:
-                    incoming_bytes_str = await tydom_client.connection.recv()
+                    try:
+                        incoming_bytes_str = await asyncio.wait_for(
+                            tydom_client.connection.recv(),
+                            timeout=tydom_client.polling_interval,
+                        )
+                    except asyncio.TimeoutError:
+                        # No message within the window: the task is still alive
+                        # and listening. Refresh the heartbeat (liveness) without
+                        # touching the message-freshness clock, then keep waiting.
+                        health_state.update_task_heartbeat("listen_tydom")
+                        continue
                     health_state.update_task_heartbeat("listen_tydom")
                     health_state.update_tydom_message_time()
                     message_handler = MessageHandler(
@@ -86,8 +98,10 @@ async def poll_device_tydom():
     while True:
         try:
             await asyncio.sleep(tydom_client.polling_interval)
-            health_state.update_task_heartbeat("poll_device_tydom")
             await tydom_client.post_refresh()
+            # Heartbeat after a successful refresh so a hung post_refresh()
+            # goes stale and is detected instead of looking alive for a cycle.
+            health_state.update_task_heartbeat("poll_device_tydom")
         except Exception as e:
             logger.warning("poll_device_tydom error : %s", e)
             break
@@ -141,21 +155,21 @@ async def shutdown(signal, loop):
         loop.stop()
 
 
-async def start_health_server():
-    if health_server is not None:
-        await health_server.start()
-
-
 def main():
     loop = asyncio.new_event_loop()
     signals = (signal.SIGHUP, signal.SIGTERM, signal.SIGINT)
     for s in signals:
         loop.add_signal_handler(s, lambda s=s: asyncio.create_task(shutdown(s, loop)))
 
+    # Start the health server synchronously so a bind failure (e.g. port in
+    # use) surfaces immediately and stops startup, instead of being lost in a
+    # fire-and-forget task while the container reports itself unhealthy.
+    if health_server is not None:
+        loop.run_until_complete(health_server.start())
+
     loop.create_task(mqtt_client.connect())
     loop.create_task(listen_tydom())
     loop.create_task(poll_device_tydom())
-    loop.create_task(start_health_server())
     loop.run_forever()
 
 

--- a/app/mqtt/MqttClient.py
+++ b/app/mqtt/MqttClient.py
@@ -15,6 +15,7 @@ from sensors.Light import Light
 from sensors.Switch import Switch
 from sensors.ShHvac import ShHvac
 from sensors.AutomaticDoor import AutomaticDoor
+from health.HealthState import HealthState
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +46,7 @@ class MqttClient:
         self.mqtt_client = None
         self.home_zone = home_zone
         self.night_zone = night_zone
+        self.health_state = HealthState()
 
     async def connect(self):
         try:
@@ -73,6 +75,7 @@ class MqttClient:
             logger.debug("Subscribing to topics (%s)", tydom_topic)
             client.subscribe("homeassistant/status", qos=0)
             client.subscribe(tydom_topic, qos=0)
+            self.health_state.update_mqtt_status(True)
         except Exception as e:
             logger.info("Mqtt connection error (%s)", e)
 
@@ -368,6 +371,6 @@ class MqttClient:
                 tydom_client=self.tydom, device_id=device_id, boost=value
             )
 
-    @staticmethod
-    def on_disconnect(cmd, packet):
+    def on_disconnect(self, cmd, packet):
         logger.info("Disconnected")
+        self.health_state.update_mqtt_status(False)

--- a/app/tydom/TydomClient.py
+++ b/app/tydom/TydomClient.py
@@ -18,6 +18,7 @@ from .const import (
     DELTADORE_AUTH_GRANT_TYPE,
     MEDIATION_URL,
 )
+from health.HealthState import HealthState
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +64,8 @@ class TydomClient:
 
         self.thermostat_cool_mode_temp_default = int(thermostat_cool_mode_temp_default)
         self.thermostat_heat_mode_temp_default = int(thermostat_heat_mode_temp_default)
+
+        self.health_state = HealthState()
 
         # Set Host, ssl context and prefix for remote or local connection
         if self.host == MEDIATION_URL:
@@ -201,6 +204,7 @@ class TydomClient:
                 ping_timeout=None,
             )
             logger.info("Connected to tydom")
+            self.health_state.update_tydom_status(True)
             return self.connection
         except Exception as e:
             logger.error("Exception when trying to connect with websocket (%s)", e)
@@ -210,6 +214,7 @@ class TydomClient:
         if self.connection is not None:
             logger.info("Disconnecting")
             await self.connection.close()
+            self.health_state.update_tydom_status(False)
             logger.info("Disconnected")
 
     # Generate 16 bytes random key for Sec-WebSocket-Keyand convert it to


### PR DESCRIPTION
## Health check

Adds an async HTTP `/health` endpoint and a Docker `HEALTHCHECK` that report the bridge **healthy** only when:
- MQTT client is connected
- Tydom WebSocket is connected
- Tydom messages are flowing (within threshold)
- All async tasks have sent a heartbeat within threshold

Addresses #263.

### Relationship to #293
This **supersedes #293** by @mikasjp (whose work is the basis of this PR — preserved via `Co-authored-by`). It re-opens the change from an in-repo branch (so CI runs) and applies the review fixes below.

### Review fixes on top of #293
- **C1 — false 503 / restart loops:** `message_timeout` was hardcoded to 300s while the default `TYDOM_POLLING_INTERVAL` is also 300s, so a quiet-but-working install would flap unhealthy. Timeouts are now derived from the polling interval (`max(600, 2× interval)`) via `HealthState.set_timeouts_from_polling_interval()`.
- **C2 — heartbeat semantics:** `listen_tydom` now refreshes its heartbeat on a bounded `recv()` timeout (liveness = "task is looping"), not only when a message arrives; `poll_device_tydom` records its heartbeat **after** a successful `post_refresh()`.
- **C3 — silent bind failure:** the health server is started **synchronously** before `run_forever()`, so a bind failure (e.g. port in use) fails fast instead of being lost in a fire-and-forget task.
- Misc: `ruff format` pass, `*.env` added to `.Dockerignore`, and a `.env.example` template.

### Validation
Built and run against a real Tydom + MQTT instance (both colima and Docker Desktop): `/health` → 200 when healthy / 503 when unhealthy / 404 otherwise, and the Docker `HEALTHCHECK` reports `healthy`.

### Note (out of scope, follow-up)
While testing, found a pre-existing bug: `MQTT_SSL` is read as a raw string and never coerced to bool, so setting `MQTT_SSL=false` is truthy and breaks the gmqtt connection (`'str' object has no attribute 'wrap_bio'`). Not fixed here to keep this PR focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)