### PR TITLE
fix: parse MQTT_SSL env var as a boolean

### DIFF
--- a/app/configuration/Configuration.py
+++ b/app/configuration/Configuration.py
@@ -57,7 +57,7 @@ class Configuration:
         self.mqtt_host = os.getenv(MQTT_HOST, "localhost")
         self.mqtt_password = os.getenv(MQTT_PASSWORD, None)
         self.mqtt_port = os.getenv(MQTT_PORT, 1883)
-        self.mqtt_ssl = os.getenv(MQTT_SSL, False)
+        self.mqtt_ssl = self._parse_bool(MQTT_SSL, os.getenv(MQTT_SSL, "false"), False)
         self.mqtt_user = os.getenv(MQTT_USER, None)
         self.tydom_alarm_home_zone = os.getenv(TYDOM_ALARM_HOME_ZONE, 1)
         self.tydom_alarm_night_zone = os.getenv(TYDOM_ALARM_NIGHT_ZONE, 2)
@@ -75,8 +75,9 @@ class Configuration:
         self.thermostat_heat_mode_temp_default = os.getenv(
             THERMOSTAT_HEAT_MODE_TEMP_DEFAULT, 16
         )
-        health_enabled_str = os.getenv(HEALTH_ENABLED, "true").lower()
-        self.health_enabled = health_enabled_str in ("true", "1", "yes")
+        self.health_enabled = self._parse_bool(
+            HEALTH_ENABLED, os.getenv(HEALTH_ENABLED, "true"), True
+        )
         self.health_port = int(os.getenv(HEALTH_PORT, 8080))
 
     @staticmethod
@@ -166,7 +167,9 @@ class Configuration:
                         self.mqtt_port = data[MQTT_PORT]
 
                     if MQTT_SSL in data and data[MQTT_SSL] != "":
-                        self.mqtt_ssl = data[MQTT_SSL]
+                        self.mqtt_ssl = self._parse_bool(
+                            MQTT_SSL, data[MQTT_SSL], self.mqtt_ssl
+                        )
 
                 except Exception as e:
                     logger.error("Parsing error %s", e)
@@ -217,6 +220,29 @@ class Configuration:
 
     def to_json(self):
         return json.dumps(self, default=lambda o: o.__dict__, sort_keys=True, indent=4)
+
+    @staticmethod
+    def _parse_bool(name, value, default):
+        """Parse a configuration value into a bool.
+
+        Accepts the same truthy/falsy tokens for every boolean setting so the
+        env-var and Hass.io paths behave identically. An unrecognized, non-empty
+        value is not silently coerced: it is logged and falls back to ``default``
+        so a typo (e.g. ``MQTT_SSL=ture``) is debuggable instead of quietly
+        disabling the feature.
+        """
+        normalized = str(value).strip().lower()
+        if normalized in ("true", "1", "yes"):
+            return True
+        if normalized in ("false", "0", "no", ""):
+            return False
+        logger.warning(
+            "Unrecognized boolean value for %s: %r; defaulting to %s",
+            name,
+            value,
+            default,
+        )
+        return default
 
     @staticmethod
     def mask_value(value, nb=1, char="*"):

--- a/app/conftest.py
+++ b/app/conftest.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+# The application modules import each other as top-level packages (e.g.
+# `from configuration.Configuration import Configuration`), matching the
+# container's WORKDIR /app. Put this directory on sys.path so tests resolve
+# imports the same way regardless of how pytest is invoked.
+sys.path.insert(0, os.path.dirname(__file__))

--- a/app/tests/test_configuration.py
+++ b/app/tests/test_configuration.py
@@ -1,0 +1,79 @@
+import json
+import logging
+from unittest.mock import mock_open
+
+import pytest
+
+from configuration.Configuration import Configuration
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    # Keep boolean settings under test isolated from the ambient environment.
+    monkeypatch.delenv("MQTT_SSL", raising=False)
+    monkeypatch.delenv("HEALTH_ENABLED", raising=False)
+
+
+# Regression guard for the gmqtt `'str' object has no attribute 'wrap_bio'`
+# crash: MQTT_SSL must resolve to a real bool, never a truthy string.
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("true", True),
+        ("True", True),
+        ("1", True),
+        ("yes", True),
+        ("false", False),
+        ("FALSE", False),
+        ("0", False),
+        ("no", False),
+        ("", False),
+        ("garbage", False),
+    ],
+)
+def test_mqtt_ssl_parsed_to_bool(monkeypatch, raw, expected):
+    monkeypatch.setenv("MQTT_SSL", raw)
+    cfg = Configuration()
+    # `is` rather than `==`: the whole point of the fix is a real bool.
+    assert cfg.mqtt_ssl is expected
+
+
+def test_mqtt_ssl_unset_defaults_false():
+    cfg = Configuration()
+    assert cfg.mqtt_ssl is False
+
+
+def test_health_enabled_unset_defaults_true():
+    cfg = Configuration()
+    assert cfg.health_enabled is True
+
+
+def test_unrecognized_mqtt_ssl_warns(monkeypatch, caplog):
+    monkeypatch.setenv("MQTT_SSL", "enable")
+    with caplog.at_level(logging.WARNING):
+        cfg = Configuration()
+    assert cfg.mqtt_ssl is False
+    assert any(
+        "MQTT_SSL" in record.message and record.levelno == logging.WARNING
+        for record in caplog.records
+    )
+
+
+@pytest.mark.parametrize(
+    "ssl_value,expected",
+    [
+        (False, False),
+        (True, True),
+        ("false", False),
+        ("true", True),
+    ],
+)
+def test_hassio_mqtt_ssl_parsed_to_bool(monkeypatch, ssl_value, expected):
+    payload = json.dumps(
+        {"TYDOM_MAC": "001A25", "TYDOM_PASSWORD": "secret", "MQTT_SSL": ssl_value}
+    )
+    cfg = Configuration()  # constructor does no file I/O
+    # Patch open only for the override so the Hass.io options file is faked.
+    monkeypatch.setattr("builtins.open", mock_open(read_data=payload))
+    cfg.override_configuration_for_hassio()
+    assert cfg.mqtt_ssl is expected


### PR DESCRIPTION
## Problem

`MQTT_SSL` was read as a raw string via `os.getenv(MQTT_SSL, False)`. Setting it to **any** value (e.g. `MQTT_SSL=false` in a `.env` or docker env) produced the truthy string `"false"`, which was passed straight through `MqttClient` into gmqtt's `client.connect(host, port, ssl)` → asyncio `create_connection(ssl=...)`. asyncio then treats the non-empty string as an `SSLContext` and crashes:

```
MQTT connection error : 'str' object has no attribute 'wrap_bio'
```

Net effect: `MQTT_SSL=false` (or any string) **broke** MQTT, while leaving it unset worked only by accident (the bool `False` default). Confirmed live.

## Fix

- Parse `MQTT_SSL` into a real `bool` via a shared `_parse_bool` helper, applied in **both** the constructor and the Hass.io override branch (`override_configuration_for_hassio`), which also tolerates a real JSON boolean from `/data/options.json`.
- Reuse the same helper for `HEALTH_ENABLED` so the truthy/falsy rule (`true`/`1`/`yes`) lives in one place instead of being duplicated three times.
- **Warn** on unrecognized, non-empty values instead of silently disabling the feature — relevant because an unrecognized `MQTT_SSL` token would otherwise downgrade to a plaintext connection with no trace.

## Tests

Adds the project's first unit tests (`app/tests/test_configuration.py`, 17 cases): the constructor parsing matrix that locks in `"false" → bool False` (the exact regression), the unrecognized-value warning, defaults, and the Hass.io branch handling both JSON bools and strings. `app/conftest.py` puts `app/` on `sys.path` so the documented `cd app && pytest` resolves the top-level imports.

## Verification

- `cd app && pytest` → **17 passed**.
- `cd app && ruff format --check . && ruff check .` → clean.
- Built the Docker image and ran with `MQTT_SSL=false`: config now logs `"mqtt_ssl": false` (a real JSON bool) and the client logs `ssl=False` and proceeds to connect — **no `wrap_bio` error**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)