### PR TITLE
fix(boiler): proper HVAC mode handling (heat/cool/off + flicker)

### DIFF
--- a/app/mqtt/MqttClient.py
+++ b/app/mqtt/MqttClient.py
@@ -278,6 +278,7 @@ class MqttClient:
                 device_id=device_id,
                 boiler_id=endpoint_id,
                 set_hvac_mode=str(value),
+                mqtt_client=self.mqtt_client,
             )
 
         elif "set_thermicLevel" in str(topic):

--- a/app/sensors/Boiler.py
+++ b/app/sensors/Boiler.py
@@ -327,19 +327,18 @@ class Boiler:
             )
 
     @staticmethod
-    async def put_hvac_mode(tydom_client, device_id, boiler_id, set_hvac_mode):
+    async def put_hvac_mode(tydom_client, device_id, boiler_id, set_hvac_mode, mqtt_client=None):
         logger.info("%s %s %s", boiler_id, "set_hvacMode", set_hvac_mode)
+        entity_id = f"{device_id}_{boiler_id}"
 
         if set_hvac_mode == "off":
             await tydom_client.put_devices_data(
                 device_id, boiler_id, "thermicLevel", "STOP"
             )
-            await tydom_client.put_devices_data(
-                device_id, boiler_id, "authorization", "STOP"
-            )
-            await tydom_client.put_devices_data(
-                device_id, boiler_id, "hvacMode", set_hvac_mode
-            )
+            await tydom_client.put_areas_data(device_id, {"authorization": "STOP"})
+            if mqtt_client is not None:
+                mqtt_client.publish(mode_state_topic.format(id=entity_id), "off", qos=0, retain=True)
+                mqtt_client.publish(preset_mode_state_topic.format(id=entity_id), "STOP", qos=0, retain=True)
         elif set_hvac_mode == "cool":
             await tydom_client.put_devices_data(
                 device_id, boiler_id, "thermicLevel", ""
@@ -350,16 +349,10 @@ class Boiler:
                 "setpoint",
                 str(tydom_client.thermostat_heat_mode_temp_default),
             )
-            await tydom_client.put_devices_data(
-                device_id, boiler_id, "authorization", "COOLING"
-            )
-            await tydom_client.put_devices_data(
-                device_id, boiler_id, "hvacMode", set_hvac_mode
-            )
+            await tydom_client.put_areas_data(device_id, {"authorization": "COOLING"})
+            if mqtt_client is not None:
+                mqtt_client.publish(mode_state_topic.format(id=entity_id), "cool", qos=0, retain=True)
         else:
-            await tydom_client.put_devices_data(
-                device_id, boiler_id, "hvacMode", "heat"
-            )
             await tydom_client.put_devices_data(
                 device_id, boiler_id, "thermicLevel", ""
             )
@@ -369,9 +362,9 @@ class Boiler:
                 "setpoint",
                 str(tydom_client.thermostat_cool_mode_temp_default),
             )
-            await tydom_client.put_devices_data(
-                device_id, boiler_id, "authorization", "HEATING"
-            )
+            await tydom_client.put_areas_data(device_id, {"authorization": "HEATING"})
+            if mqtt_client is not None:
+                mqtt_client.publish(mode_state_topic.format(id=entity_id), "heat", qos=0, retain=True)
 
     @staticmethod
     async def put_thermic_level(tydom_client, device_id, boiler_id, set_thermic_level):

--- a/app/sensors/Boiler.py
+++ b/app/sensors/Boiler.py
@@ -338,24 +338,26 @@ class Boiler:
         logger.info("%s %s %s", boiler_id, "set_hvacMode", set_hvac_mode)
         entity_id = f"{device_id}_{boiler_id}"
 
-        # Note: switching the zone-level heat/cool authorization from HA is NOT
-        # supported by Tydom over the public protocol used here — PUT /areas/<id>/data
-        # returns HTTP 404 (the boiler's device_id is not a valid area path), and
-        # PUT /devices/<id>/endpoints/<id>/data with "authorization" returns 200 but
-        # is silently ignored by Tydom. The real channel appears to be the
-        # "events/home/hvac" stream emitted by the master thermostat, which is not
-        # yet handled (see tydom2mqtt issue #177).
+        # Two control surfaces are involved:
         #
-        # What does work and is therefore implemented here:
-        #   - off  : per-thermostat thermicLevel = STOP      (turns this thermostat off)
-        #   - cool : per-thermostat thermicLevel = ""         (releases the STOP, thermostat
-        #            follows the area's current authorization). Setpoint is reset to the
-        #            configured default.
-        #   - heat : same as cool, with the heat-mode default setpoint.
+        #   1. Zone-level HVAC direction (heat pump direction):
+        #        PUT /home/hvac/data {"mode": "STOP"|"HEATING"|"COOLING"}
+        #      Tydom broadcasts the result via PUT /devices/data (per-thermostat
+        #      authorization update) and POST /events/home/hvac.
         #
-        # Optimistic MQTT publishes give immediate UI feedback; the next /areas/data
-        # poll re-publishes the authoritative mode (combining thermicLevel and the
-        # area authorization), correcting any short-lived mismatch.
+        #   2. Per-thermostat preset:
+        #        PUT /devices/<id>/endpoints/<id>/data thermicLevel = STOP / "" / preset
+        #      "STOP" parks the thermostat regardless of zone direction; "" releases
+        #      it to follow the zone direction.
+        #
+        # Mapping HA modes:
+        #   - off  : thermicLevel = STOP only (per-thermostat). Does NOT change zone
+        #            direction, so siblings sharing the heat pump keep running.
+        #   - cool : zone -> COOLING, thermicLevel -> "" (active), reset setpoint
+        #   - heat : zone -> HEATING, thermicLevel -> "" (active), reset setpoint
+        #
+        # Optimistic MQTT publishes give immediate UI feedback; the next push from
+        # Tydom (broadcast on the open WebSocket) confirms or corrects the state.
         if set_hvac_mode == "off":
             await tydom_client.put_devices_data(
                 device_id, boiler_id, "thermicLevel", "STOP"
@@ -364,6 +366,7 @@ class Boiler:
                 mqtt_client.publish(mode_state_topic.format(id=entity_id), "off", qos=0, retain=True)
                 mqtt_client.publish(preset_mode_state_topic.format(id=entity_id), "STOP", qos=0, retain=True)
         elif set_hvac_mode == "cool":
+            await tydom_client.put_home_hvac_mode("COOLING")
             await tydom_client.put_devices_data(
                 device_id, boiler_id, "thermicLevel", ""
             )
@@ -376,6 +379,7 @@ class Boiler:
             if mqtt_client is not None:
                 mqtt_client.publish(mode_state_topic.format(id=entity_id), "cool", qos=0, retain=True)
         else:
+            await tydom_client.put_home_hvac_mode("HEATING")
             await tydom_client.put_devices_data(
                 device_id, boiler_id, "thermicLevel", ""
             )

--- a/app/sensors/Boiler.py
+++ b/app/sensors/Boiler.py
@@ -338,11 +338,28 @@ class Boiler:
         logger.info("%s %s %s", boiler_id, "set_hvacMode", set_hvac_mode)
         entity_id = f"{device_id}_{boiler_id}"
 
+        # Note: switching the zone-level heat/cool authorization from HA is NOT
+        # supported by Tydom over the public protocol used here — PUT /areas/<id>/data
+        # returns HTTP 404 (the boiler's device_id is not a valid area path), and
+        # PUT /devices/<id>/endpoints/<id>/data with "authorization" returns 200 but
+        # is silently ignored by Tydom. The real channel appears to be the
+        # "events/home/hvac" stream emitted by the master thermostat, which is not
+        # yet handled (see tydom2mqtt issue #177).
+        #
+        # What does work and is therefore implemented here:
+        #   - off  : per-thermostat thermicLevel = STOP      (turns this thermostat off)
+        #   - cool : per-thermostat thermicLevel = ""         (releases the STOP, thermostat
+        #            follows the area's current authorization). Setpoint is reset to the
+        #            configured default.
+        #   - heat : same as cool, with the heat-mode default setpoint.
+        #
+        # Optimistic MQTT publishes give immediate UI feedback; the next /areas/data
+        # poll re-publishes the authoritative mode (combining thermicLevel and the
+        # area authorization), correcting any short-lived mismatch.
         if set_hvac_mode == "off":
             await tydom_client.put_devices_data(
                 device_id, boiler_id, "thermicLevel", "STOP"
             )
-            await tydom_client.put_areas_data(device_id, {"authorization": "STOP"})
             if mqtt_client is not None:
                 mqtt_client.publish(mode_state_topic.format(id=entity_id), "off", qos=0, retain=True)
                 mqtt_client.publish(preset_mode_state_topic.format(id=entity_id), "STOP", qos=0, retain=True)
@@ -356,7 +373,6 @@ class Boiler:
                 "setpoint",
                 str(tydom_client.thermostat_heat_mode_temp_default),
             )
-            await tydom_client.put_areas_data(device_id, {"authorization": "COOLING"})
             if mqtt_client is not None:
                 mqtt_client.publish(mode_state_topic.format(id=entity_id), "cool", qos=0, retain=True)
         else:
@@ -369,7 +385,6 @@ class Boiler:
                 "setpoint",
                 str(tydom_client.thermostat_cool_mode_temp_default),
             )
-            await tydom_client.put_areas_data(device_id, {"authorization": "HEATING"})
             if mqtt_client is not None:
                 mqtt_client.publish(mode_state_topic.format(id=entity_id), "heat", qos=0, retain=True)
 

--- a/app/sensors/Boiler.py
+++ b/app/sensors/Boiler.py
@@ -59,6 +59,7 @@ class Boiler:
         self.current_temp = None
         self.current_setpoint = None
         self.current_authorization = None
+        self.current_thermic_level = None
 
     async def setup(self):
         self.config = {}
@@ -140,6 +141,10 @@ class Boiler:
                 self.id,
                 "current_authorization",
             )
+            self.current_thermic_level = await self.tydom_client.get_in_memory(
+                self.id,
+                "current_thermic_level",
+            )
 
             if (
                 "authorization" in self.attributes
@@ -148,6 +153,12 @@ class Boiler:
                 self.current_authorization = self.attributes["authorization"]
                 await self.tydom_client.set_in_memory(
                     self.id, "current_authorization", self.current_authorization
+                )
+
+            if "thermicLevel" in self.attributes:
+                self.current_thermic_level = self.attributes["thermicLevel"]
+                await self.tydom_client.set_in_memory(
+                    self.id, "current_thermic_level", self.current_thermic_level
                 )
 
             if "temperature" in self.attributes:
@@ -264,16 +275,6 @@ class Boiler:
                     )
 
             if "thermicLevel" in self.attributes and self.attributes["thermicLevel"]:
-                self.mqtt.mqtt_client.publish(
-                    self.config["mode_state_topic"],
-                    "off"
-                    if self.attributes["thermicLevel"] == "STOP"
-                    else "cool"
-                    if self.attributes["thermicLevel"] is None
-                    else "heat",
-                    qos=0,
-                    retain=True,
-                )
                 if await self.tydom_client.get_thermostat_custom_presets() is None:
                     self.mqtt.mqtt_client.publish(
                         self.config["preset_mode_state_topic"],
@@ -297,23 +298,29 @@ class Boiler:
                     qos=0,
                     retain=True,
                 )
-            if "authorization" in self.attributes:
+            # Coherent hvac mode: combine thermicLevel (per-thermostat preset)
+            # and authorization (area heat/cool direction). Single publish to
+            # avoid the off/cool flicker when both arrive in the same update.
+            if self.current_thermic_level is not None or self.current_authorization is not None:
+                if self.current_thermic_level == "STOP":
+                    mode = "off"
+                elif self.current_authorization == "STOP":
+                    mode = "off"
+                elif self.current_authorization == "COOLING":
+                    mode = "cool"
+                elif self.current_authorization == "HEATING":
+                    mode = "heat"
+                else:
+                    mode = "heat"
                 logger.debug(
-                    "authorization : publish  %s to %s",
-                    self.config["mode_state_topic"],
-                    "off"
-                    if self.attributes["authorization"] == "STOP"
-                    else "cool"
-                    if self.attributes["authorization"] == "COOLING"
-                    else "heat",
+                    "hvacMode publish %s (thermicLevel=%s authorization=%s)",
+                    mode,
+                    self.current_thermic_level,
+                    self.current_authorization,
                 )
                 self.mqtt.mqtt_client.publish(
                     self.config["mode_state_topic"],
-                    "off"
-                    if self.attributes["authorization"] == "STOP"
-                    else "cool"
-                    if self.attributes["authorization"] == "COOLING"
-                    else "heat",
+                    mode,
                     qos=0,
                     retain=True,
                 )

--- a/app/sensors/Boiler.py
+++ b/app/sensors/Boiler.py
@@ -301,7 +301,10 @@ class Boiler:
             # Coherent hvac mode: combine thermicLevel (per-thermostat preset)
             # and authorization (area heat/cool direction). Single publish to
             # avoid the off/cool flicker when both arrive in the same update.
-            if self.current_thermic_level is not None or self.current_authorization is not None:
+            if (
+                self.current_thermic_level is not None
+                or self.current_authorization is not None
+            ):
                 if self.current_thermic_level == "STOP":
                     mode = "off"
                 elif self.current_authorization == "STOP":
@@ -334,7 +337,9 @@ class Boiler:
             )
 
     @staticmethod
-    async def put_hvac_mode(tydom_client, device_id, boiler_id, set_hvac_mode, mqtt_client=None):
+    async def put_hvac_mode(
+        tydom_client, device_id, boiler_id, set_hvac_mode, mqtt_client=None
+    ):
         logger.info("%s %s %s", boiler_id, "set_hvacMode", set_hvac_mode)
         entity_id = f"{device_id}_{boiler_id}"
 
@@ -363,8 +368,15 @@ class Boiler:
                 device_id, boiler_id, "thermicLevel", "STOP"
             )
             if mqtt_client is not None:
-                mqtt_client.publish(mode_state_topic.format(id=entity_id), "off", qos=0, retain=True)
-                mqtt_client.publish(preset_mode_state_topic.format(id=entity_id), "STOP", qos=0, retain=True)
+                mqtt_client.publish(
+                    mode_state_topic.format(id=entity_id), "off", qos=0, retain=True
+                )
+                mqtt_client.publish(
+                    preset_mode_state_topic.format(id=entity_id),
+                    "STOP",
+                    qos=0,
+                    retain=True,
+                )
         elif set_hvac_mode == "cool":
             await tydom_client.put_home_hvac_mode("COOLING")
             await tydom_client.put_devices_data(
@@ -377,7 +389,9 @@ class Boiler:
                 str(tydom_client.thermostat_heat_mode_temp_default),
             )
             if mqtt_client is not None:
-                mqtt_client.publish(mode_state_topic.format(id=entity_id), "cool", qos=0, retain=True)
+                mqtt_client.publish(
+                    mode_state_topic.format(id=entity_id), "cool", qos=0, retain=True
+                )
         else:
             await tydom_client.put_home_hvac_mode("HEATING")
             await tydom_client.put_devices_data(
@@ -390,7 +404,9 @@ class Boiler:
                 str(tydom_client.thermostat_cool_mode_temp_default),
             )
             if mqtt_client is not None:
-                mqtt_client.publish(mode_state_topic.format(id=entity_id), "heat", qos=0, retain=True)
+                mqtt_client.publish(
+                    mode_state_topic.format(id=entity_id), "heat", qos=0, retain=True
+                )
 
     @staticmethod
     async def put_thermic_level(tydom_client, device_id, boiler_id, set_thermic_level):

--- a/app/tydom/MessageHandler.py
+++ b/app/tydom/MessageHandler.py
@@ -405,6 +405,8 @@ class MessageHandler:
                 msg_type = "msg_html"
             elif "productName" in first:
                 msg_type = "msg_info"
+            elif "mode" in first and "support" in data:
+                msg_type = "msg_area_authorization"
 
             if msg_type is None:
                 logger.warning("Unknown message type received (%s)", data)
@@ -432,6 +434,11 @@ class MessageHandler:
 
                     elif msg_type == "msg_info":
                         pass
+
+                    elif msg_type == "msg_area_authorization":
+                        parsed = json.loads(data)
+                        logger.debug("Zone authorization notification: mode=%s support=%s",
+                                     parsed.get("mode"), parsed.get("support"))
                 except Exception as e:
                     logger.error("Error on parsing tydom response (%s)", e)
                     logger.error("Incoming data (%s)", data)

--- a/app/tydom/MessageHandler.py
+++ b/app/tydom/MessageHandler.py
@@ -437,8 +437,11 @@ class MessageHandler:
 
                     elif msg_type == "msg_area_authorization":
                         parsed = json.loads(data)
-                        logger.debug("Zone authorization notification: mode=%s support=%s",
-                                     parsed.get("mode"), parsed.get("support"))
+                        logger.debug(
+                            "Zone authorization notification: mode=%s support=%s",
+                            parsed.get("mode"),
+                            parsed.get("support"),
+                        )
                 except Exception as e:
                     logger.error("Error on parsing tydom response (%s)", e)
                     logger.error("Incoming data (%s)", data)

--- a/app/tydom/TydomClient.py
+++ b/app/tydom/TydomClient.py
@@ -301,6 +301,28 @@ class TydomClient:
         await self.connection.send(a_bytes)
         return 0
 
+    async def put_home_hvac_mode(self, mode):
+        """Set the zone-level HVAC mode (STOP / HEATING / COOLING).
+
+        Tells the heat pump which way to run (or stop). Tydom acknowledges
+        with a 200 OK then broadcasts the resulting state to all clients via
+        PUT /devices/data (per-thermostat authorization update) and
+        POST /events/home/hvac.
+        """
+        body = '{"mode":"' + mode + '"}'
+        str_request = (
+            self.cmd_prefix
+            + "PUT /home/hvac/data HTTP/1.1\r\nContent-Length: "
+            + str(len(body))
+            + "\r\nContent-Type: application/json; charset=UTF-8\r\nTransac-Id: 0\r\n\r\n"
+            + body
+            + "\r\n\r\n"
+        )
+        a_bytes = bytes(str_request, "ascii")
+        logger.debug("Sending message to tydom (%s %s)", "PUT home hvac data", body)
+        await self.connection.send(a_bytes)
+        return 0
+
     async def put_alarm_cdata(self, device_id, alarm_id=None, value=None, zone_id=None):
         # Credits to @mgcrea on github !
         # AWAY # "PUT /devices/{}/endpoints/{}/cdata?name=alarmCmd HTTP/1.1\r\ncontent-length: 29\r\ncontent-type: application/json; charset=utf-8\r\ntransac-id: request_124\r\n\r\n\r\n{"value":"ON","pwd":{}}\r\n\r\n"


### PR DESCRIPTION
Same change as #296 (by @jokoast), rebuilt on a branch in this repo with one extra commit applying `ruff format` so the CI `ruff format --check` job passes.

## What this adds on top of #296

- `style(boiler): apply ruff format to satisfy CI` — wraps the long hvac-mode condition, the `put_hvac_mode` signature, the optimistic `mqtt_client.publish(...)` calls, and the zone-authorization debug log. No behavior change.

Verified locally:
- `ruff format --check` → all files formatted
- `ruff check` → all checks pass
- `py_compile` → OK

## Original change (#296)

Fixes HVAC mode handling for Delta Dore Tydom thermostats (heat/cool/off) and a state-flicker bug. See #296 for the full protocol analysis and hardware verification.

## Note

This branch carries the full #296 feature plus the format fix. Open as an alternative to #296 — close whichever isn't merged. Outstanding non-blocking review points from #296 (silent `else→heat` fallback, optimistic-publish failure logging, `json.dumps` consistency) are tracked in the review comment on #296 and are **not** addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)