### PR TITLE
fix(tysense): numeric values + HA classes/units (corrige #271)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-alpine3.17
+FROM python:3.11-alpine3.22
 
 LABEL org.opencontainers.image.description="Deltadore Tydom to MQTT Bridge"
 

--- a/app/sensors/Sensor.py
+++ b/app/sensors/Sensor.py
@@ -37,11 +37,18 @@ class Sensor:
 
         if "unit_of_measurement" in tydom_attributes_payload.keys():
             self.unit_of_measurement = tydom_attributes_payload["unit_of_measurement"]
+        else:
+            # Fallback for known sensor types that should have units
+            self.unit_of_measurement = self._get_default_unit_for_sensor(elem_name)
 
         self.mqtt = mqtt
         self.binary = False
 
-        if "unit_of_measurement" not in tydom_attributes_payload.keys() and (
+        # Check if this should be a binary sensor (no units and boolean-like values)
+        has_unit = ("unit_of_measurement" in tydom_attributes_payload.keys() or 
+                   hasattr(self, 'unit_of_measurement') and self.unit_of_measurement is not None)
+        
+        if not has_unit and (
             self.elem_value in ["0", "1", "true", "false", "True", "False", "ON", "OFF"]
             or isinstance(self.elem_value, bool)
         ):
@@ -65,6 +72,30 @@ class Sensor:
         else:
             self.json_attributes_topic = sensor_json_attributes_topic.format(id=self.id)
             self.config_topic = sensor_config_topic.format(id=self.id)
+
+    def _get_default_unit_for_sensor(self, elem_name):
+        """Get default unit of measurement for known sensor types."""
+        default_units = {
+            "outTemperature": "°C",
+            "temperature": "°C",
+            "lightPower": "W",
+            "power": "W", 
+            "energyInstantTotElec": "A",
+            "energyInstantTotElecP": "W",
+            "energyTotIndexWatt": "Wh",
+            "energyIndexHeatWatt": "Wh",
+            "energyIndexECSWatt": "Wh",
+            "energyIndexHeatGas": "Wh",
+            # Add more common sensor types
+            "humidity": "%",
+            "pressure": "hPa",
+            "batteryLevel": "%",
+            "current": "A",
+            "voltage": "V",
+            "energy": "Wh",
+            "setpoint": "°C",
+        }
+        return default_units.get(elem_name, None)
 
     # SENSOR:
     # None: Generic sensor. This is the default and doesn’t need to be set.
@@ -122,7 +153,8 @@ class Sensor:
         except AttributeError:
             pass
         try:
-            self.config["unit_of_measurement"] = self.unit_of_measurement
+            if hasattr(self, 'unit_of_measurement') and self.unit_of_measurement is not None:
+                self.config["unit_of_measurement"] = self.unit_of_measurement
         except AttributeError:
             pass
 
@@ -153,8 +185,9 @@ class Sensor:
                     self.json_attributes_topic, self.elem_value, qos=0, retain=True
                 )
             if not self.binary:
+                unit_info = f" {self.unit_of_measurement}" if hasattr(self, 'unit_of_measurement') and self.unit_of_measurement else ""
                 logger.info(
-                    "Sensor created / updated : %s %s", self.name, self.elem_value
+                    "Sensor created / updated : %s %s%s", self.name, self.elem_value, unit_info
                 )
             else:
                 logger.info(

--- a/app/sensors/Sensor.py
+++ b/app/sensors/Sensor.py
@@ -45,9 +45,11 @@ class Sensor:
         self.binary = False
 
         # Check if this should be a binary sensor (no units and boolean-like values)
-        has_unit = ("unit_of_measurement" in tydom_attributes_payload.keys() or 
-                   hasattr(self, 'unit_of_measurement') and self.unit_of_measurement is not None)
-        
+        has_unit = (
+            "unit_of_measurement" in tydom_attributes_payload.keys()
+            or self.unit_of_measurement is not None
+        )
+
         if not has_unit and (
             self.elem_value in ["0", "1", "true", "false", "True", "False", "ON", "OFF"]
             or isinstance(self.elem_value, bool)
@@ -79,7 +81,7 @@ class Sensor:
             "outTemperature": "°C",
             "temperature": "°C",
             "lightPower": "W",
-            "power": "W", 
+            "power": "W",
             "energyInstantTotElec": "A",
             "energyInstantTotElecP": "W",
             "energyTotIndexWatt": "Wh",
@@ -153,7 +155,7 @@ class Sensor:
         except AttributeError:
             pass
         try:
-            if hasattr(self, 'unit_of_measurement') and self.unit_of_measurement is not None:
+            if self.unit_of_measurement is not None:
                 self.config["unit_of_measurement"] = self.unit_of_measurement
         except AttributeError:
             pass
@@ -185,9 +187,14 @@ class Sensor:
                     self.json_attributes_topic, self.elem_value, qos=0, retain=True
                 )
             if not self.binary:
-                unit_info = f" {self.unit_of_measurement}" if hasattr(self, 'unit_of_measurement') and self.unit_of_measurement else ""
+                unit_info = (
+                    f" {self.unit_of_measurement}" if self.unit_of_measurement else ""
+                )
                 logger.info(
-                    "Sensor created / updated : %s %s%s", self.name, self.elem_value, unit_info
+                    "Sensor created / updated : %s %s%s",
+                    self.name,
+                    self.elem_value,
+                    unit_info,
                 )
             else:
                 logger.info(

--- a/app/tydom/MessageHandler.py
+++ b/app/tydom/MessageHandler.py
@@ -727,7 +727,9 @@ class MessageHandler:
                                 # Convert common numeric strings (e.g., "123 W", "12,3") to number
                                 if isinstance(normalized_value, str):
                                     sanitized = normalized_value.replace(",", ".")
-                                    match = re.search(r"[-+]?[0-9]*\.?[0-9]+", sanitized)
+                                    match = re.search(
+                                        r"[-+]?[0-9]*\.?[0-9]+", sanitized
+                                    )
                                     if match:
                                         val_str = match.group(0)
                                         normalized_value = (
@@ -777,13 +779,6 @@ class MessageHandler:
                             attr_alarm["alarm_name"] = "Tyxal Alarm"
                             attr_alarm["name"] = "Tyxal Alarm"
                             attr_alarm["device_type"] = "alarm_control_panel"
-                            
-                            # Add unit information for temperature sensors in alarm devices
-                            if element_name == "outTemperature":
-                                attr_alarm["unit_of_measurement"] = "°C"
-                                attr_alarm["device_class"] = "temperature"
-                                attr_alarm["state_class"] = "measurement"
-                            
                             attr_alarm[element_name] = element_value
 
                     if (

--- a/app/tydom/MessageHandler.py
+++ b/app/tydom/MessageHandler.py
@@ -744,8 +744,7 @@ class MessageHandler:
                                 # Temperature in Celsius
                                 attr_sensor["device_class"] = "temperature"
                                 attr_sensor["state_class"] = "measurement"
-                                # Keep unit consistent with the rest of the project (uses "C")
-                                attr_sensor["unit_of_measurement"] = "C"
+                                attr_sensor["unit_of_measurement"] = "°C"
                             elif element_name == "lightPower":
                                 # Power in Watts
                                 attr_sensor["device_class"] = "power"
@@ -778,6 +777,13 @@ class MessageHandler:
                             attr_alarm["alarm_name"] = "Tyxal Alarm"
                             attr_alarm["name"] = "Tyxal Alarm"
                             attr_alarm["device_type"] = "alarm_control_panel"
+                            
+                            # Add unit information for temperature sensors in alarm devices
+                            if element_name == "outTemperature":
+                                attr_alarm["unit_of_measurement"] = "°C"
+                                attr_alarm["device_class"] = "temperature"
+                                attr_alarm["state_class"] = "measurement"
+                            
                             attr_alarm[element_name] = element_value
 
                     if (

--- a/app/tydom/MessageHandler.py
+++ b/app/tydom/MessageHandler.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 from http.client import HTTPResponse
 from http.server import BaseHTTPRequestHandler
 from io import BytesIO
@@ -719,7 +720,39 @@ class MessageHandler:
                             attr_sensor["name"] = print_id
                             attr_sensor["device_type"] = "sensor"
                             attr_sensor["element_name"] = element_name
-                            attr_sensor[element_name] = element_value
+
+                            # Normalize value types and enrich HA discovery for graphing
+                            normalized_value = element_value
+                            try:
+                                # Convert common numeric strings (e.g., "123 W", "12,3") to number
+                                if isinstance(normalized_value, str):
+                                    sanitized = normalized_value.replace(",", ".")
+                                    match = re.search(r"[-+]?[0-9]*\.?[0-9]+", sanitized)
+                                    if match:
+                                        val_str = match.group(0)
+                                        normalized_value = (
+                                            float(val_str)
+                                            if "." in val_str
+                                            else int(val_str)
+                                        )
+                            except Exception:
+                                # Keep original value if conversion fails
+                                normalized_value = element_value
+
+                            # Home Assistant typing and units
+                            if element_name == "outTemperature":
+                                # Temperature in Celsius
+                                attr_sensor["device_class"] = "temperature"
+                                attr_sensor["state_class"] = "measurement"
+                                # Keep unit consistent with the rest of the project (uses "C")
+                                attr_sensor["unit_of_measurement"] = "C"
+                            elif element_name == "lightPower":
+                                # Power in Watts
+                                attr_sensor["device_class"] = "power"
+                                attr_sensor["state_class"] = "measurement"
+                                attr_sensor["unit_of_measurement"] = "W"
+
+                            attr_sensor[element_name] = normalized_value
 
                     if type_of_id == "boiler":
                         if (


### PR DESCRIPTION
Reprend et corrige #271 (le fork n'autorisait pas l'édition par les mainteneurs, d'où cette branche dans le repo principal).

Le correctif d'origine est bon dans son intention — publier les valeurs Tysense Sun/Thermo en numérique avec `device_class`/`state_class`/`unit_of_measurement` pour que Home Assistant les graphe. Le chemin `sensorThermo`/`sensorSun` est conservé tel quel. Cette branche ajoute deux corrections par-dessus.

## Corrections

### 🔴 Capteurs HA parasites créés par la branche alarme
Le bloc alarme ajoutait `unit_of_measurement`/`device_class`/`state_class` comme clés de premier niveau sur `attr_alarm`. Or `Alarm.update_sensors()` itère sur **toutes** les clés et crée un `Sensor` par clé (en n'excluant que `device_type`/`id`/`device_id`/`endpoint_id`). Ces métadonnées étaient donc publiées comme de vrais capteurs HA bidons (`unit_of_measurement = °C`, `device_class = temperature`, `state_class = measurement`). De plus la valeur de température de l'alarme n'était jamais normalisée — l'enrichissement n'apportait aucun bénéfice de graphe. Le bloc est retiré pour restaurer le comportement correct.

### 🔴 Formatage / style Ruff (la CI échouait)
- quotes simples → doubles, espaces en fin de ligne, lignes trop longues
- suppression des `hasattr()` redondants (`unit_of_measurement` est désormais toujours initialisé)

## Vérification
```
ruff format --check  → 2 files already formatted
ruff check app/      → All checks passed!
```
Branche rebasée sur `master` (diff limité à `Dockerfile`, `Sensor.py`, `MessageHandler.py`).

## Restant à discuter (non traité ici)
- Triple source de vérité pour les unités : `device_conso_unit_of_measurement` utilise `"C"` alors que ce code utilise `"°C"` — à aligner.
- `_get_default_unit_for_sensor` s'applique globalement à tous les capteurs ; des clés génériques (`humidity`, `power`, `current`…) peuvent modifier la détection binaire de capteurs hors périmètre Tysense.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
