### PR TITLE
feat(garage): support toggle-only relay devices configured as garage/gate covers

### DIFF
--- a/app/sensors/Garage.py
+++ b/app/sensors/Garage.py
@@ -23,11 +23,8 @@ class Garage:
         self.endpoint_id = self.attributes["endpoint_id"]
         self.id = self.attributes["id"]
         self.name = self.attributes["cover_name"]
-        try:
-            self.current_level = self.attributes["level"]
-        except Exception as e:
-            logger.error(e)
-            self.current_level = None
+        # Toggle-only relays never report "level" (no position feedback).
+        self.current_level = self.attributes.get("level")
 
         self.set_level = set_level
         self.current_position = set_level

--- a/app/sensors/Garage.py
+++ b/app/sensors/Garage.py
@@ -12,12 +12,21 @@ cover_level_topic = "cover/tydom/{id}/current_level"
 cover_set_level_topic = "cover/tydom/{id}/set_garageLevel"
 cover_attributes_topic = "cover/tydom/{id}/attributes"
 
+# Toggle-only relays have no open/close/stop distinction and no position
+# feedback, so they are exposed as a single-action button (mirrors
+# AutomaticDoor) instead of a Cover with three buttons that all send the
+# same pulse.
+button_config_topic = "homeassistant/button/tydom/{id}/config"
+button_command_topic = "button/tydom/{id}/set_garageLevelCmd"
+button_state_topic = "button/tydom/{id}/state"
+
 
 class Garage:
     def __init__(self, tydom_attributes, set_level=None, mqtt=None):
         self.device = None
         self.config = None
         self.config_topic = None
+        self.is_button = False
         self.attributes = tydom_attributes
         self.device_id = self.attributes["device_id"]
         self.endpoint_id = self.attributes["endpoint_id"]
@@ -58,29 +67,55 @@ class Garage:
             "name": self.name,
             "identifiers": self.id,
         }
-        self.config_topic = cover_config_topic.format(id=self.id)
+        self.is_button = self.is_toggle_only()
 
-        if self.is_toggle_only():
-            payload_open, payload_close, payload_stop = "TOGGLE", "TOGGLE", "TOGGLE"
+        if self.is_button:
+            self.config_topic = button_config_topic.format(id=self.id)
+            self.config = {
+                "name": None,  # set an MQTT entity's name to None to mark it as the main feature of a device
+                "unique_id": self.id,
+                "device": self.device,
+                "command_topic": button_command_topic.format(id=self.id),
+                "button_state_topic": button_state_topic.format(id=self.id),
+                "payload_press": "TOGGLE",
+                "icon": "mdi:gate"
+                if self.attributes["cover_class"] == "gate"
+                else "mdi:garage",
+            }
+
+            if self.mqtt is not None:
+                # Clear a stale Cover entity, in case this device was first
+                # set up as ON/OFF/STOP before its capability metadata
+                # (install-sync) confirmed it's toggle-only.
+                self.mqtt.mqtt_client.publish(
+                    cover_config_topic.format(id=self.id), "", qos=0, retain=True
+                )
         else:
-            payload_open, payload_close, payload_stop = "ON", "OFF", "STOP"
+            self.config_topic = cover_config_topic.format(id=self.id)
+            self.config = {
+                "name": None,  # set an MQTT entity's name to None to mark it as the main feature of a device
+                "unique_id": self.id,
+                "command_topic": cover_command_topic.format(id=self.id),
+                "position_topic": cover_position_topic.format(id=self.id),
+                "level_topic": cover_level_topic.format(id=self.id),
+                "set_position_topic": cover_set_level_topic.format(id=self.id),
+                "payload_open": "ON",
+                "payload_close": "OFF",
+                "payload_stop": "STOP",
+                "retain": "false",
+                "device": self.device,
+                "device_class": self.attributes["cover_class"],
+            }
+            self.config["json_attributes_topic"] = cover_attributes_topic.format(
+                id=self.id
+            )
 
-        self.config = {
-            "name": None,  # set an MQTT entity's name to None to mark it as the main feature of a device
-            "unique_id": self.id,
-            "command_topic": cover_command_topic.format(id=self.id),
-            "position_topic": cover_position_topic.format(id=self.id),
-            "level_topic": cover_level_topic.format(id=self.id),
-            "set_position_topic": cover_set_level_topic.format(id=self.id),
-            "payload_open": payload_open,
-            "payload_close": payload_close,
-            "payload_stop": payload_stop,
-            "retain": "false",
-            "device": self.device,
-            "device_class": self.attributes["cover_class"],
-        }
-
-        self.config["json_attributes_topic"] = cover_attributes_topic.format(id=self.id)
+            if self.mqtt is not None:
+                # Clear a stale button entity, in case capability metadata
+                # changed since this device was last set up as toggle-only.
+                self.mqtt.mqtt_client.publish(
+                    button_config_topic.format(id=self.id), "", qos=0, retain=True
+                )
 
         if self.mqtt is not None:
             self.mqtt.mqtt_client.publish(
@@ -96,9 +131,23 @@ class Garage:
             logger.error("GarageDoor Horizontal sensors Error :")
             logger.error(e)
 
-        self.level_topic = cover_state_topic.format(
-            id=self.id, current_level=self.current_level
-        )
+        if self.is_button:
+            if self.mqtt is not None:
+                self.mqtt.mqtt_client.publish(
+                    self.config["button_state_topic"],
+                    self.attributes,
+                    qos=0,
+                    retain=True,
+                )
+
+            logger.info(
+                "GarageDoor Horizontal (toggle button) created / updated : %s %s",
+                self.name,
+                self.id,
+            )
+            return
+
+        self.level_topic = cover_state_topic.format(id=self.id)
 
         if self.mqtt is not None:
             # and 'position' in self.attributes:

--- a/app/sensors/Garage.py
+++ b/app/sensors/Garage.py
@@ -1,5 +1,6 @@
 import json
 import logging
+
 from .Sensor import Sensor
 
 logger = logging.getLogger(__name__)
@@ -36,6 +37,23 @@ class Garage:
 
         self.mqtt = mqtt
 
+    def is_toggle_only(self):
+        # Some relays (e.g. Tyxia 4620, x3d_rm) only expose a single
+        # "TOGGLE" levelCmd, with no OPEN/CLOSE/STOP and no position
+        # feedback; the connected gate/garage motor decides what a pulse
+        # means. Real positional garage motors advertise a genuine
+        # multi-value enum and must keep the ON/OFF/STOP mapping.
+        # Metadata may not have arrived yet (install-sync race) -- default
+        # to False (ON/OFF/STOP) in that case.
+        # Imported lazily (tydom.MessageHandler imports this module at its
+        # own top level, so a module-level import here would deadlock
+        # whichever module loads first).
+        import tydom.MessageHandler as message_handler
+
+        unique_id = str(self.endpoint_id) + "_" + str(self.device_id)
+        capabilities = message_handler.device_metadata.get(unique_id, {})
+        return capabilities.get("levelCmd") == ["TOGGLE"]
+
     async def setup(self):
         self.device = {
             "manufacturer": "Delta Dore",
@@ -44,6 +62,12 @@ class Garage:
             "identifiers": self.id,
         }
         self.config_topic = cover_config_topic.format(id=self.id)
+
+        if self.is_toggle_only():
+            payload_open, payload_close, payload_stop = "TOGGLE", "TOGGLE", "TOGGLE"
+        else:
+            payload_open, payload_close, payload_stop = "ON", "OFF", "STOP"
+
         self.config = {
             "name": None,  # set an MQTT entity's name to None to mark it as the main feature of a device
             "unique_id": self.id,
@@ -51,9 +75,9 @@ class Garage:
             "position_topic": cover_position_topic.format(id=self.id),
             "level_topic": cover_level_topic.format(id=self.id),
             "set_position_topic": cover_set_level_topic.format(id=self.id),
-            "payload_open": "ON",
-            "payload_close": "OFF",
-            "payload_stop": "STOP",
+            "payload_open": payload_open,
+            "payload_close": payload_close,
+            "payload_stop": payload_stop,
             "retain": "false",
             "device": self.device,
             "device_class": self.attributes["cover_class"],

--- a/app/tests/test_garage.py
+++ b/app/tests/test_garage.py
@@ -1,0 +1,89 @@
+import asyncio
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from sensors.Garage import Garage
+from tydom.MessageHandler import device_metadata
+
+
+@pytest.fixture(autouse=True)
+def _clean_device_metadata():
+    device_metadata.clear()
+    yield
+    device_metadata.clear()
+
+
+def make_garage(device_id=1, endpoint_id=2, cover_class="gate"):
+    return Garage(
+        tydom_attributes={
+            "device_id": device_id,
+            "endpoint_id": endpoint_id,
+            "id": f"{device_id}_{endpoint_id}",
+            "cover_name": "Gate 1",
+            "cover_class": cover_class,
+        },
+        mqtt=MagicMock(),
+    )
+
+
+def test_is_toggle_only_defaults_false_when_metadata_missing():
+    # Race between install-sync and the first parse_endpoint_data call: no
+    # metadata known yet for this device -- must not crash and must default
+    # to the existing ON/OFF/STOP behavior.
+    garage = make_garage()
+    assert garage.is_toggle_only() is False
+
+
+def test_is_toggle_only_true_for_toggle_only_relay():
+    device_metadata["2_1"] = {"levelCmd": ["TOGGLE"]}
+    garage = make_garage(device_id=1, endpoint_id=2)
+    assert garage.is_toggle_only() is True
+
+
+def test_is_toggle_only_false_for_real_positional_motor():
+    device_metadata["2_1"] = {"levelCmd": ["OPEN", "CLOSE", "STOP"]}
+    garage = make_garage(device_id=1, endpoint_id=2)
+    assert garage.is_toggle_only() is False
+
+
+def test_setup_publishes_toggle_payloads_for_toggle_only_relay():
+    device_metadata["2_1"] = {"levelCmd": ["TOGGLE"]}
+    garage = make_garage(device_id=1, endpoint_id=2)
+
+    asyncio.run(garage.setup())
+
+    config = json.loads(garage.mqtt.mqtt_client.publish.call_args[0][1])
+    assert config["payload_open"] == "TOGGLE"
+    assert config["payload_close"] == "TOGGLE"
+    assert config["payload_stop"] == "TOGGLE"
+
+
+def test_setup_publishes_on_off_stop_for_positional_motor():
+    device_metadata["2_1"] = {"levelCmd": ["OPEN", "CLOSE", "STOP"]}
+    garage = make_garage(device_id=1, endpoint_id=2)
+
+    asyncio.run(garage.setup())
+
+    config = json.loads(garage.mqtt.mqtt_client.publish.call_args[0][1])
+    assert config["payload_open"] == "ON"
+    assert config["payload_close"] == "OFF"
+    assert config["payload_stop"] == "STOP"
+
+
+def test_put_garage_positioncmd_forwards_toggle_verbatim():
+    async def scenario():
+        tydom_client = MagicMock()
+
+        async def fake_put_devices_data(*args):
+            fake_put_devices_data.calls.append(args)
+
+        fake_put_devices_data.calls = []
+        tydom_client.put_devices_data = fake_put_devices_data
+
+        await Garage.put_garage_positionCmd(tydom_client, "device1", "cover1", "TOGGLE")
+        return fake_put_devices_data.calls
+
+    calls = asyncio.run(scenario())
+    assert calls == [("device1", "cover1", "levelCmd", "TOGGLE")]

--- a/app/tests/test_garage.py
+++ b/app/tests/test_garage.py
@@ -48,16 +48,30 @@ def test_is_toggle_only_false_for_real_positional_motor():
     assert garage.is_toggle_only() is False
 
 
-def test_setup_publishes_toggle_payloads_for_toggle_only_relay():
+def test_setup_publishes_button_entity_for_toggle_only_relay():
     device_metadata["2_1"] = {"levelCmd": ["TOGGLE"]}
     garage = make_garage(device_id=1, endpoint_id=2)
 
     asyncio.run(garage.setup())
 
-    config = json.loads(garage.mqtt.mqtt_client.publish.call_args[0][1])
-    assert config["payload_open"] == "TOGGLE"
-    assert config["payload_close"] == "TOGGLE"
-    assert config["payload_stop"] == "TOGGLE"
+    topic, payload = garage.mqtt.mqtt_client.publish.call_args[0][:2]
+    config = json.loads(payload)
+    assert topic == "homeassistant/button/tydom/1_2/config"
+    assert config["payload_press"] == "TOGGLE"
+    assert config["command_topic"] == "button/tydom/1_2/set_garageLevelCmd"
+
+
+def test_setup_clears_stale_cover_entity_for_toggle_only_relay():
+    device_metadata["2_1"] = {"levelCmd": ["TOGGLE"]}
+    garage = make_garage(device_id=1, endpoint_id=2)
+
+    asyncio.run(garage.setup())
+
+    calls = garage.mqtt.mqtt_client.publish.call_args_list
+    assert (
+        "homeassistant/cover/tydom/1_2/config",
+        "",
+    ) == calls[0][0][:2]
 
 
 def test_setup_publishes_on_off_stop_for_positional_motor():
@@ -70,6 +84,19 @@ def test_setup_publishes_on_off_stop_for_positional_motor():
     assert config["payload_open"] == "ON"
     assert config["payload_close"] == "OFF"
     assert config["payload_stop"] == "STOP"
+
+
+def test_setup_clears_stale_button_entity_for_positional_motor():
+    device_metadata["2_1"] = {"levelCmd": ["OPEN", "CLOSE", "STOP"]}
+    garage = make_garage(device_id=1, endpoint_id=2)
+
+    asyncio.run(garage.setup())
+
+    calls = garage.mqtt.mqtt_client.publish.call_args_list
+    assert (
+        "homeassistant/button/tydom/1_2/config",
+        "",
+    ) == calls[0][0][:2]
 
 
 def test_put_garage_positioncmd_forwards_toggle_verbatim():

--- a/app/tests/test_message_handler.py
+++ b/app/tests/test_message_handler.py
@@ -1,0 +1,172 @@
+import asyncio
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from tydom.MessageHandler import (
+    MessageHandler,
+    device_metadata,
+    device_name,
+    device_type,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registries():
+    # These dicts are shared module-level state (mirroring the app's own
+    # long-lived process), so tests must not leak entries into each other.
+    device_metadata.clear()
+    device_name.clear()
+    device_type.clear()
+    yield
+    device_metadata.clear()
+    device_name.clear()
+    device_type.clear()
+
+
+def make_handler():
+    return MessageHandler(
+        incoming_bytes=b"", tydom_client=MagicMock(), mqtt_client=MagicMock()
+    )
+
+
+# Regression guard: an endpoint `metadata` push (device capability
+# description) used to fall through to parse_devices_data -> parse_endpoint_data,
+# which assumed every endpoint has a "data" key and raised KeyError('data').
+def test_metadata_push_does_not_crash_for_non_garage_device():
+    device_type["55_100"] = "light"
+    device_name["55_100"] = "Kitchen Light"
+
+    payload = [
+        {
+            "id": 100,
+            "endpoints": [
+                {
+                    "id": 55,
+                    "error": 0,
+                    "metadata": [
+                        {
+                            "name": "levelCmd",
+                            "type": "string",
+                            "permission": "w",
+                            "enum_values": ["ON", "OFF", "TOGGLE"],
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+
+    handler = make_handler()
+    asyncio.run(handler.parse_response(json.dumps(payload)))
+
+    assert device_metadata["55_100"]["levelCmd"] == ["ON", "OFF", "TOGGLE"]
+    # Not a garage/gate device: no discovery config should be (re)published.
+    handler.mqtt_client.mqtt_client.publish.assert_not_called()
+
+
+def test_metadata_push_captures_toggle_only_levelcmd():
+    device_type["1784555123_1784555123"] = "garage_door_horizontal"
+    device_name["1784555123_1784555123"] = "Gate 1"
+
+    payload = [
+        {
+            "id": 1784555123,
+            "endpoints": [
+                {
+                    "id": 1784555123,
+                    "error": 0,
+                    "metadata": [
+                        {
+                            "name": "levelCmd",
+                            "type": "string",
+                            "permission": "w",
+                            "validity": "INFINITE",
+                            "shared": False,
+                            "enum_values": ["TOGGLE"],
+                        },
+                        {
+                            "name": "thermicDefect",
+                            "type": "boolean",
+                            "permission": "r",
+                        },
+                        {
+                            "name": "localisation",
+                            "type": "string",
+                            "permission": "w",
+                            "enum_values": ["START"],
+                        },
+                    ],
+                }
+            ],
+        }
+    ]
+
+    handler = make_handler()
+    asyncio.run(handler.parse_response(json.dumps(payload)))
+
+    assert device_metadata["1784555123_1784555123"]["levelCmd"] == ["TOGGLE"]
+    assert device_metadata["1784555123_1784555123"]["localisation"] == ["START"]
+
+
+def test_metadata_arrival_republishes_garage_discovery_as_toggle():
+    unique_id = "1784555123_1784555123"
+    device_type[unique_id] = "garage_door_horizontal"
+    device_name[unique_id] = "Gate 1"
+
+    payload = [
+        {
+            "id": 1784555123,
+            "endpoints": [
+                {
+                    "id": 1784555123,
+                    "error": 0,
+                    "metadata": [
+                        {"name": "levelCmd", "enum_values": ["TOGGLE"]},
+                    ],
+                }
+            ],
+        }
+    ]
+
+    handler = make_handler()
+    asyncio.run(handler.parse_response(json.dumps(payload)))
+
+    handler.mqtt_client.mqtt_client.publish.assert_called_once()
+    topic, config_json = handler.mqtt_client.mqtt_client.publish.call_args[0]
+    assert topic == f"homeassistant/cover/tydom/{unique_id}/config"
+    config = json.loads(config_json)
+    assert config["payload_open"] == "TOGGLE"
+    assert config["payload_close"] == "TOGGLE"
+    assert config["payload_stop"] == "TOGGLE"
+
+
+def test_metadata_with_real_enum_does_not_trigger_republish():
+    # A genuine positional garage motor advertising a real multi-value enum:
+    # the toggle-only determination never becomes True, so no republish is
+    # needed the first time metadata is learned (still not "changed").
+    unique_id = "42_42"
+    device_type[unique_id] = "garage_door"
+    device_name[unique_id] = "Real Garage Motor"
+
+    payload = [
+        {
+            "id": 42,
+            "endpoints": [
+                {
+                    "id": 42,
+                    "error": 0,
+                    "metadata": [
+                        {"name": "levelCmd", "enum_values": ["OPEN", "CLOSE", "STOP"]},
+                    ],
+                }
+            ],
+        }
+    ]
+
+    handler = make_handler()
+    asyncio.run(handler.parse_response(json.dumps(payload)))
+
+    assert device_metadata[unique_id]["levelCmd"] == ["OPEN", "CLOSE", "STOP"]
+    handler.mqtt_client.mqtt_client.publish.assert_not_called()

--- a/app/tests/test_message_handler.py
+++ b/app/tests/test_message_handler.py
@@ -133,13 +133,16 @@ def test_metadata_arrival_republishes_garage_discovery_as_toggle():
     handler = make_handler()
     asyncio.run(handler.parse_response(json.dumps(payload)))
 
-    handler.mqtt_client.mqtt_client.publish.assert_called_once()
-    topic, config_json = handler.mqtt_client.mqtt_client.publish.call_args[0]
-    assert topic == f"homeassistant/cover/tydom/{unique_id}/config"
+    calls = handler.mqtt_client.mqtt_client.publish.call_args_list
+    assert len(calls) == 2
+    # The old ON/OFF/STOP Cover entity (published before metadata confirmed
+    # this device is toggle-only) is cleared out...
+    assert calls[0][0][:2] == (f"homeassistant/cover/tydom/{unique_id}/config", "")
+    # ...and replaced by a single-action button entity.
+    topic, config_json = calls[1][0]
+    assert topic == f"homeassistant/button/tydom/{unique_id}/config"
     config = json.loads(config_json)
-    assert config["payload_open"] == "TOGGLE"
-    assert config["payload_close"] == "TOGGLE"
-    assert config["payload_stop"] == "TOGGLE"
+    assert config["payload_press"] == "TOGGLE"
 
 
 def test_metadata_with_real_enum_does_not_trigger_republish():

--- a/app/tydom/MessageHandler.py
+++ b/app/tydom/MessageHandler.py
@@ -310,6 +310,11 @@ deviceSmokeKeywords = ["techSmokeDefect"]
 device_name = dict()
 device_endpoint = dict()
 device_type = dict()
+# Per-device_id_endpoint_id capability description, populated from endpoint
+# `metadata` pushes: {unique_id: {attribute_name: enum_values}}
+device_metadata = dict()
+
+garage_gate_usage_types = ("garage_door_horizontal", "garage_door", "gate")
 
 
 class MessageHandler:
@@ -398,6 +403,8 @@ class MessageHandler:
                 msg_type = "msg_config"
             elif "cmetadata" in data:
                 msg_type = "msg_cmetadata"
+            elif "metadata" in data:
+                msg_type = "msg_metadata"
             elif "cdata" in data:
                 msg_type = "msg_cdata"
             elif "id" in first:
@@ -421,6 +428,10 @@ class MessageHandler:
                     elif msg_type == "msg_cmetadata":
                         parsed = json.loads(data)
                         await self.parse_cmeta_data(parsed=parsed)
+
+                    elif msg_type == "msg_metadata":
+                        parsed = json.loads(data)
+                        await self.parse_endpoint_metadata(parsed=parsed)
 
                     elif msg_type == "msg_data":
                         parsed = json.loads(data)
@@ -575,6 +586,67 @@ class MessageHandler:
                                         logger.debug("Add poll device : " + url)
 
         logger.debug("Metadata configuration updated")
+
+    async def parse_endpoint_metadata(self, parsed):
+        # Endpoint capability description push, e.g.:
+        # [{"id": <device_id>, "endpoints": [{"id": <endpoint_id>, "error": 0,
+        #   "metadata": [{"name": "levelCmd", "enum_values": ["TOGGLE"], ...}]}]}]
+        # Distinct from `cmetadata` (config-metadata) handled above.
+        if not isinstance(parsed, list):
+            logger.warning("Unknown metadata message format (%s)", parsed)
+            return
+
+        for i in parsed:
+            device_id = i.get("id")
+            for endpoint in i.get("endpoints", []):
+                if endpoint.get("error") != 0 or "metadata" not in endpoint:
+                    continue
+
+                endpoint_id = endpoint["id"]
+                unique_id = str(endpoint_id) + "_" + str(device_id)
+                capabilities = device_metadata.setdefault(unique_id, {})
+                was_toggle_only = capabilities.get("levelCmd") == ["TOGGLE"]
+
+                for elem in endpoint["metadata"]:
+                    elem_name = elem.get("name")
+                    if elem_name is not None and "enum_values" in elem:
+                        capabilities[elem_name] = elem["enum_values"]
+
+                is_toggle_only = capabilities.get("levelCmd") == ["TOGGLE"]
+                type_of_id = self.get_type_from_id(unique_id)
+
+                if (
+                    is_toggle_only != was_toggle_only
+                    and type_of_id in garage_gate_usage_types
+                ):
+                    await self.republish_garage_discovery(
+                        device_id, endpoint_id, unique_id, type_of_id
+                    )
+
+        logger.debug("Endpoint metadata updated")
+
+    async def republish_garage_discovery(
+        self, device_id, endpoint_id, unique_id, type_of_id
+    ):
+        # Metadata can arrive after the garage/gate entity was already
+        # published with the default ON/OFF/STOP payloads (or before any
+        # state data has been seen at all). Re-publish the retained
+        # discovery config now that the toggle-only determination changed,
+        # without touching state topics (no fresh state data is available
+        # here).
+        name_of_id = self.get_name_from_id(unique_id)
+        print_id = name_of_id if len(name_of_id) != 0 else device_id
+        attr_garage = {
+            "device_id": device_id,
+            "endpoint_id": endpoint_id,
+            "id": str(device_id) + "_" + str(endpoint_id),
+            "cover_name": print_id,
+            "name": print_id,
+            "device_type": "garage",
+            "cover_class": "garage" if type_of_id == "garage_door" else "gate",
+        }
+        garage = Garage(tydom_attributes=attr_garage, mqtt=self.mqtt_client)
+        await garage.setup()
 
     async def parse_devices_data(self, parsed):
         if isinstance(parsed, list):

--- a/app/tydom/TydomClient.py
+++ b/app/tydom/TydomClient.py
@@ -466,6 +466,7 @@ class TydomClient:
     async def get_data(self):
         await self.get_configs_file()
         await self.get_devices_cmeta()
+        await self.get_devices_meta()
         await self.get_devices_data()
         await self.get_areas_data()
 


### PR DESCRIPTION
## Summary
- Some relays (e.g. Delta Dore Tyxia 4620, protocol `x3d_rm`) only expose a single `TOGGLE` `levelCmd`, with no `OPEN`/`CLOSE`/`STOP` and no position feedback — the gate/garage motor wired behind the relay decides what a pulse means. When configured in the Tydom app under a `garage_door_horizontal`/`garage_door`/`gate` usage profile, `sensors/Garage.py` always published `ON`/`OFF`/`STOP` payloads, which the Tydom box silently rejects, so open/close/stop from Home Assistant did nothing.
- Parse the endpoint `metadata` push (device capability description) in a new `parse_endpoint_metadata`, instead of letting it fall through to `parse_devices_data` → `parse_endpoint_data`, which assumed a `data` key and crashed with `KeyError: 'data'`. Capabilities (writable attribute enum values, e.g. `levelCmd`) are stored per `endpoint_id_device_id` in a new `device_metadata` dict, the same way `device_name`/`device_type` already are.
- Actually request that metadata: `TydomClient.get_devices_meta()` (`GET /devices/meta`) was defined but never called, so `device_metadata` stayed empty and `Garage.is_toggle_only()` always returned `False` in production. It's now called from `get_data()` alongside the other startup fetches.
- `Garage.is_toggle_only()` detects `levelCmd == ["TOGGLE"]` for the device. Since a toggle-only relay has no real open/close/stop distinction and no position feedback, it's exposed as a single-action MQTT **button** entity (mirroring the existing `AutomaticDoor` sensor) instead of a Cover — mapping all three Cover commands to the same `TOGGLE` payload would just give three identical buttons in Home Assistant. Real positional garage motors (genuine multi-value enum) are unaffected and keep the existing Cover with `ON`/`OFF`/`STOP` mapping.
- If metadata hasn't arrived yet when the discovery config is first published (install-sync race), it safely defaults to the Cover/`ON`/`OFF`/`STOP` behavior. If metadata arrives later and flips the toggle-only determination, the stale discovery config of the other entity type is cleared and the correct one is (re-)published.

## Test plan
- [x] `ruff format --check .`
- [x] `ruff check .`
- [x] `pytest` (29 passed), including coverage in `app/tests/test_message_handler.py` and `app/tests/test_garage.py`:
  - metadata push no longer crashes for non-garage devices (regression guard for the `KeyError: 'data'` crash)
  - `levelCmd` capability capture from a real device metadata push sample
  - toggle-only relay is published as a button entity (`payload_press: "TOGGLE"`); positional motor keeps the `ON`/`OFF`/`STOP` Cover
  - missing metadata defaults to the `ON`/`OFF`/`STOP` Cover
  - discovery config is re-published (and the stale entity of the other domain cleared) when the toggle-only determination changes
